### PR TITLE
Add no_std + alloc support for ucd-util

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -18,4 +18,6 @@ cargo doc --all --verbose
 cargo test --all --verbose
 if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
   cargo bench --all --verbose --no-run
+  # Test no_std + alloc mode for ucd-util
+  cargo test --lib --manifest-path ucd-util/Cargo.toml --no-default-features --features "alloc"
 fi

--- a/ucd-util/Cargo.toml
+++ b/ucd-util/Cargo.toml
@@ -11,3 +11,10 @@ repository = "https://github.com/BurntSushi/rucd"
 readme = "README.md"
 keywords = ["unicode", "database", "character", "property"]
 license = "MIT/Apache-2.0"
+
+[features]
+default = ["std"]
+# Disable this on-by-default feature and add "alloc" to allow use in no_std builds
+std = []
+# Required for use in no_std builds, presently nightly-only
+alloc = []

--- a/ucd-util/src/hangul.rs
+++ b/ucd-util/src/hangul.rs
@@ -1,3 +1,6 @@
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::string::{String, ToString};
+
 use unicode_tables::jamo_short_name::JAMO_SHORT_NAME;
 
 // This implementation should correspond to the algorithms described in

--- a/ucd-util/src/ideograph.rs
+++ b/ucd-util/src/ideograph.rs
@@ -1,3 +1,6 @@
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::string::String;
+
 /// A set of ranges that corresponds to the set of all ideograph codepoints.
 ///
 /// These ranges are defined in Unicode 4.8 Table 4-13.

--- a/ucd-util/src/lib.rs
+++ b/ucd-util/src/lib.rs
@@ -9,7 +9,18 @@ canonicalization functions, you'll need to supply your own table, which can
 be generated using `ucd-generate`.
 */
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
+
 #![deny(missing_docs)]
+
+#[cfg(all(test, not(feature = "std")))]
+#[macro_use]
+extern crate std;
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[macro_use]
+extern crate alloc;
 
 mod hangul;
 mod ideograph;

--- a/ucd-util/src/name.rs
+++ b/ucd-util/src/name.rs
@@ -1,3 +1,6 @@
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::string::String;
+
 /// Normalize the given character name in place according to UAX44-LM2.
 ///
 /// See: http://unicode.org/reports/tr44/#UAX44-LM2
@@ -137,6 +140,9 @@ fn symbolic_name_normalize_bytes(slice: &mut [u8]) -> &mut [u8] {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    use alloc::string::{String, ToString};
+
     use super::{
         character_name_normalize, character_name_normalize_bytes,
         symbolic_name_normalize, symbolic_name_normalize_bytes,


### PR DESCRIPTION
## What

The addition of feature flags and conditional compilation blocks to make ucd-util work in either `std` or `no_std` + `alloc` environments.

The default-on "std" feature flag controls whether or not to compile in `#![no_std]` mode, but due to the presence of `String` in core APIs, the "alloc" feature flag must also specified and the toolchain fixed to nightly.

## How

As usual, building and testing for standard use does not change.

From the repo's root directory test out the no_std build with at **nightly** toolchain:
```
cargo test --lib --manifest-path ucd-util/Cargo.toml --no-default-features --features "alloc"
```
## Why

This PR is part of an effort to get regex and its dependencies to operate in `no_std` + `alloc` mode, and ucd-util is used by regex-syntax, which regex uses.

See also: https://github.com/BurntSushi/utf8-ranges/pull/8 and https://github.com/BurntSushi/aho-corasick/pull/28