### PR TITLE
Replace rucd references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ description = """
 A program for generating packed representations of the Unicode character
 database that can be efficiently searched.
 """
-documentation = "https://github.com/BurntSushi/rucd"
-homepage = "https://github.com/BurntSushi/rucd"
-repository = "https://github.com/BurntSushi/rucd"
+documentation = "https://github.com/BurntSushi/ucd-generate"
+homepage = "https://github.com/BurntSushi/ucd-generate"
+repository = "https://github.com/BurntSushi/ucd-generate"
 readme = "README.md"
 keywords = ["unicode", "generate", "character", "table", "fst"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
On crates.io, the repository link goes to rucd instead of here. This is slightly annoying, and definitely problematic when you don't know where to find the actual repository.