### PR TITLE
Add option for generating case mapping tables

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -119,7 +119,14 @@ case-folding emits a table of Simple case folding mappings from codepoint
 to codepoint. When codepoints are mapped according to this table, then case
 differences (according to Unicode) are eliminated.
 ";
+const ABOUT_CASE_MAPPING: &'static str = "\
+case-mapping emits case mapping tables, which map from a codepoint to a
+list of codepoints (currently up to three), and are used to convert
+text between lower, upper, and title cases.
 
+This command currently has no support for emitting the conditional case
+mapping data, and can only produce the unconditional mapping tables.
+";
 const ABOUT_GRAPHEME_CLUSTER_BREAK: &'static str = "\
 grapheme-cluster-break emits the table of property values and their
 corresponding codepoints for the Grapheme_Cluster_Break property.
@@ -422,6 +429,21 @@ pub fn app() -> App<'static, 'static> {
             "Emit a table where each codepoint includes all possible \
              Simple mappings.",
         ));
+    let cmd_case_mapping = SubCommand::with_name("case-mapping")
+        .author(crate_authors!())
+        .version(crate_version!())
+        .template(TEMPLATE_SUB)
+        .about("Create unconditional case mapping tables for upper, lower and title case.")
+        .before_help(ABOUT_CASE_MAPPING)
+        .arg(flag_name("CASE_MAPPING"))
+        .arg(ucd_dir.clone())
+        .arg(flag_chars.clone())
+        .arg(Arg::with_name("simple").long("simple").help(
+            "Only emit the simple case mapping tables \
+             (emit maps of codepoint to codepoint, \
+             ignoring rules from SpecialCasing.txt)",
+        ));
+
     let cmd_grapheme_cluster_break =
         SubCommand::with_name("grapheme-cluster-break")
             .author(crate_authors!())
@@ -543,6 +565,7 @@ pub fn app() -> App<'static, 'static> {
         .subcommand(cmd_property_names)
         .subcommand(cmd_property_values)
         .subcommand(cmd_case_folding_simple)
+        .subcommand(cmd_case_mapping)
         .subcommand(cmd_grapheme_cluster_break)
         .subcommand(cmd_word_break)
         .subcommand(cmd_sentence_break)

--- a/src/case_mapping.rs
+++ b/src/case_mapping.rs
@@ -1,0 +1,68 @@
+use std::collections::BTreeMap;
+
+use ucd_parse::{SpecialCaseMapping, UcdFile, UnicodeData};
+
+use args::ArgMatches;
+use error::Result;
+
+pub fn command(args: ArgMatches) -> Result<()> {
+    let dir = args.ucd_dir()?;
+    let mut lower_map: BTreeMap<u32, Vec<u32>> = BTreeMap::new();
+    let mut upper_map: BTreeMap<u32, Vec<u32>> = BTreeMap::new();
+    let mut title_map: BTreeMap<u32, Vec<u32>> = BTreeMap::new();
+    let mut wtr = args.writer("case_mapping")?;
+    for item in UnicodeData::from_dir(dir)? {
+        let item = item?;
+        if let Some(lower) = item.simple_lowercase_mapping {
+            lower_map.insert(item.codepoint.value(), vec![lower.value()]);
+        }
+        if let Some(upper) = item.simple_uppercase_mapping {
+            upper_map.insert(item.codepoint.value(), vec![upper.value()]);
+        }
+        if let Some(title) = item.simple_titlecase_mapping {
+            title_map.insert(item.codepoint.value(), vec![title.value()]);
+        }
+    }
+    if args.is_present("simple") {
+        let upper_map =
+            upper_map.into_iter().map(|(k, v)| (k, v[0])).collect();
+        let lower_map =
+            lower_map.into_iter().map(|(k, v)| (k, v[0])).collect();
+        let title_map =
+            title_map.into_iter().map(|(k, v)| (k, v[0])).collect();
+        wtr.codepoint_to_codepoint("LOWER", &upper_map)?;
+        wtr.codepoint_to_codepoint("UPPER", &lower_map)?;
+        wtr.codepoint_to_codepoint("TITLE", &title_map)?;
+    } else {
+        for special in SpecialCaseMapping::from_dir(&dir)? {
+            let special = special?;
+            if !special.conditions.is_empty() {
+                // There should probably be an option to output these too, but
+                // I'm not sure how they're typically used...
+                continue;
+            }
+            if !special.lowercase.is_empty() {
+                lower_map.insert(
+                    special.codepoint.value(),
+                    special.lowercase.iter().map(|v| v.value()).collect(),
+                );
+            }
+            if !special.uppercase.is_empty() {
+                upper_map.insert(
+                    special.codepoint.value(),
+                    special.uppercase.iter().map(|v| v.value()).collect(),
+                );
+            }
+            if !special.titlecase.is_empty() {
+                title_map.insert(
+                    special.codepoint.value(),
+                    special.titlecase.iter().map(|v| v.value()).collect(),
+                );
+            }
+        }
+        wtr.codepoint_to_codepoints("LOWER", &lower_map)?;
+        wtr.codepoint_to_codepoints("UPPER", &upper_map)?;
+        wtr.codepoint_to_codepoints("TITLE", &upper_map)?;
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ mod writer;
 mod age;
 mod brk;
 mod case_folding;
+mod case_mapping;
 mod general_category;
 mod jamo_short_name;
 mod names;
@@ -75,6 +76,7 @@ fn run() -> Result<()> {
         ("case-folding-simple", Some(m)) => {
             case_folding::command(ArgMatches::new(m))
         }
+        ("case-mapping", Some(m)) => case_mapping::command(ArgMatches::new(m)),
         ("grapheme-cluster-break", Some(m)) => {
             brk::grapheme_cluster(ArgMatches::new(m))
         }


### PR DESCRIPTION
I did this at roughly the same time as #16 and in my head for some reason I had thought it would be hard to rebase to not include the C stuff. I don't know why I thought that (AFAICT there would be no merge conflict, and even if there was, it looks like I did it months ago anyway. EDIT: Ah, actually there's a patch somewhere that goes on top of what's here for C output of this stuff I think. If you accept the C output patch I'll go dig that up too).

That said, there's less of a need for this in Rust as it's in libcore anyway (C on the other hand...).

It skips the conditional rules, which might be useful for some cases, but I'm not sure what code that handles them tends to look like, so I'm not sure what representation is convenient/efficient.

Alternatively if you have an opinion on how conditional rules should be output, let me know and I can do that as another flag maybe.