### PR TITLE
Add --rust-enum option to general-category sub-command

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -191,6 +191,9 @@ pub fn app() -> App<'static, 'static> {
                 "Emit a single table that maps codepoints to categories.",
             ),
         )
+        .arg(Arg::with_name("rust-enum").long("rust-enum").help(
+            "Emit a Rust enum and a table that maps codepoints to categories.",
+        ))
         .arg(Arg::with_name("include").long("include").takes_value(true).help(
             "A comma separated list of categories to include. \
              When absent, all categories are included.",

--- a/src/general_category.rs
+++ b/src/general_category.rs
@@ -36,7 +36,7 @@ pub fn command(args: ArgMatches) -> Result<()> {
     // As a special case, collect all unassigned codepoints.
     let unassigned_name = propvals.canonical("gc", "unassigned")?.to_string();
     bycat.insert(unassigned_name.clone(), BTreeSet::new());
-    for cp in 0..(0x10FFFF + 1) {
+    for cp in 0..=0x10FFFF {
         if !assigned.contains(&cp) {
             bycat.get_mut(&unassigned_name).unwrap().insert(cp);
         }

--- a/src/general_category.rs
+++ b/src/general_category.rs
@@ -45,7 +45,7 @@ pub fn command(args: ArgMatches) -> Result<()> {
     // But don't do this when printing an enumeration, because in an
     // enumeration each codepoint should belong to exactly one category, which
     // is not true if we include related categories.
-    if !args.is_present("enum") {
+    if !args.is_present("enum") && !args.is_present("rust-enum") {
         for (name, set) in related(&propvals, &bycat) {
             if filter.contains(&name) {
                 bycat.insert(name, set);
@@ -61,6 +61,9 @@ pub fn command(args: ArgMatches) -> Result<()> {
     let mut wtr = args.writer("general_category")?;
     if args.is_present("enum") {
         wtr.ranges_to_enum(args.name(), &bycat)?;
+    } else if args.is_present("rust-enum") {
+        let variants = bycat.keys().map(String::as_str).collect::<Vec<_>>();
+        wtr.ranges_to_rust_enum(args.name(), &variants, &bycat)?;
     } else {
         wtr.names(bycat.keys().filter(|n| filter.contains(n)))?;
         for (name, set) in bycat {


### PR DESCRIPTION
Adds a `--rust-enum` option to the `general-category` command.

The inclusive range change can be removed if you want. It was suggested when folks from work were reviewing my changes. I checked that it's supported by the MSRV.

Sample output:

```rust
// DO NOT EDIT THIS FILE. IT WAS AUTOMATICALLY GENERATED BY:
//
//  ucd-generate general-category --rust-enum /home/wmoore/Downloads/ucd-9
//
// ucd-generate is available on crates.io.

#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
pub enum GeneralCategory {
  ClosePunctuation, ConnectorPunctuation, Control, CurrencySymbol,
  DashPunctuation, DecimalNumber, EnclosingMark, FinalPunctuation, Format,
  InitialPunctuation, LetterNumber, LineSeparator, LowercaseLetter,
  MathSymbol, ModifierLetter, ModifierSymbol, NonspacingMark, OpenPunctuation,
  OtherLetter, OtherNumber, OtherPunctuation, OtherSymbol, ParagraphSeparator,
  PrivateUse, SpaceSeparator, SpacingMark, Surrogate, TitlecaseLetter,
  Unassigned, UppercaseLetter,
}

pub const GENERAL_CATEGORY: &'static [(u32, u32, GeneralCategory)] = &[
  (0, 31, GeneralCategory::Control),
  (32, 32, GeneralCategory::SpaceSeparator),
  (33, 35, GeneralCategory::OtherPunctuation),
  (36, 36, GeneralCategory::CurrencySymbol),
  (37, 39, GeneralCategory::OtherPunctuation),
  (40, 40, GeneralCategory::OpenPunctuation),
  ⋮
];
```