### PR TITLE
Add version to header of generated files

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1061,7 +1061,11 @@ impl Writer {
         writeln!(self.wtr, "//")?;
         writeln!(self.wtr, "//  {}", argv.join(" "))?;
         writeln!(self.wtr, "//")?;
-        writeln!(self.wtr, "// ucd-generate is available on crates.io.")?;
+        writeln!(
+            self.wtr,
+            "// ucd-generate {} is available on crates.io.",
+            env!("CARGO_PKG_VERSION")
+        )?;
         self.wrote_header = true;
         Ok(())
     }


### PR DESCRIPTION
To help ensure that regeneration of files is repeatable this PR adds the version of `ucd-generate` used to generate the file to the header.