### PR TITLE
Add support for EastAsianWidth.txt to ucd-parse

### DIFF
--- a/ucd-parse/src/east_asian_width.rs
+++ b/ucd-parse/src/east_asian_width.rs
@@ -1,0 +1,63 @@
+use std::path::Path;
+use std::str::FromStr;
+
+use crate::common::{
+    parse_codepoint_association, CodepointIter, Codepoints, UcdFile,
+    UcdFileByCodepoint,
+};
+use crate::error::Error;
+
+/// A single row in the `EastAsianWidth.txt` file, describing the value of the
+/// `East_Asian_Width` property.
+///
+/// Note: All code points, assigned or unassigned, that are not listed in
+/// EastAsianWidth.txt file are given the value "N".
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct EastAsianWidth {
+    /// The codepoint or codepoint range for this entry.
+    pub codepoints: Codepoints,
+    /// One of "A", "F", "H", "N", "Na", "W".
+    pub width: String,
+}
+
+impl UcdFile for EastAsianWidth {
+    fn relative_file_path() -> &'static Path {
+        Path::new("EastAsianWidth.txt")
+    }
+}
+
+impl UcdFileByCodepoint for EastAsianWidth {
+    fn codepoints(&self) -> CodepointIter {
+        self.codepoints.into_iter()
+    }
+}
+
+impl FromStr for EastAsianWidth {
+    type Err = Error;
+
+    fn from_str(line: &str) -> Result<EastAsianWidth, Error> {
+        let (codepoints, width) = parse_codepoint_association(line)?;
+        Ok(EastAsianWidth { codepoints, width: width.to_string() })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EastAsianWidth;
+
+    #[test]
+    fn parse_single() {
+        let line = "27E7;Na          # Pe         MATHEMATICAL RIGHT WHITE SQUARE BRACKET\n";
+        let row: EastAsianWidth = line.parse().unwrap();
+        assert_eq!(row.codepoints, 0x27E7);
+        assert_eq!(row.width, "Na");
+    }
+
+    #[test]
+    fn parse_range() {
+        let line = "1F57B..1F594;N   # So    [26] LEFT HAND TELEPHONE RECEIVER..REVERSED VICTORY HAND\n";
+        let row: EastAsianWidth = line.parse().unwrap();
+        assert_eq!(row.codepoints, (0x1F57B, 0x1F594));
+        assert_eq!(row.width, "N");
+    }
+}

--- a/ucd-parse/src/lib.rs
+++ b/ucd-parse/src/lib.rs
@@ -16,6 +16,7 @@ pub use crate::arabic_shaping::ArabicShaping;
 pub use crate::bidi_mirroring_glyph::BidiMirroring;
 pub use crate::case_folding::{CaseFold, CaseStatus};
 pub use crate::core_properties::CoreProperty;
+pub use crate::east_asian_width::EastAsianWidth;
 pub use crate::emoji_properties::EmojiProperty;
 pub use crate::grapheme_cluster_break::{
     GraphemeClusterBreak, GraphemeClusterBreakTest,
@@ -50,6 +51,7 @@ mod arabic_shaping;
 mod bidi_mirroring_glyph;
 mod case_folding;
 mod core_properties;
+mod east_asian_width;
 mod emoji_properties;
 mod grapheme_cluster_break;
 mod jamo_short_name;


### PR DESCRIPTION
No support for ucd-generate, mostly because it's both tricky, and AFAICT unless you're actually doing east asian typography, it's probably not what you want unless you're going to build on top of it (and https://www.unicode.org/reports/tr11/ even says exactly this at the end of the "scope" section).

I wasn't sure if the width strings should be enums. I left them as-is since nothing else in the library parses stuff out like that, and I guess this is more future-proof.