### PR TITLE
Add support for parsing the UCD version to ucd-parse and include it in ucd-generate output

### DIFF
--- a/benches/tables/fst/general_category.rs
+++ b/benches/tables/fst/general_category.rs
@@ -2,6 +2,8 @@
 //
 //  ucd-generate general-category ./ucd-13.0.0 --exclude unassigned --enum --fst-dir benches/tables/fst
 //
+// from UCD version 13.0.0.
+//
 // ucd-generate 0.2.6 is available on crates.io.
 
 pub const GENERAL_CATEGORY_ENUM: &'static [&'static str] = &[

--- a/benches/tables/fst/jamo_short_name.rs
+++ b/benches/tables/fst/jamo_short_name.rs
@@ -2,6 +2,8 @@
 //
 //  ucd-generate jamo-short-name ./ucd-13.0.0 --fst-dir benches/tables/fst
 //
+// from UCD version 13.0.0.
+//
 // ucd-generate 0.2.6 is available on crates.io.
 
 lazy_static! {

--- a/benches/tables/fst/names.rs
+++ b/benches/tables/fst/names.rs
@@ -2,6 +2,8 @@
 //
 //  ucd-generate names ./ucd-13.0.0 --no-aliases --no-hangul --no-ideograph --fst-dir benches/tables/fst
 //
+// from UCD version 13.0.0.
+//
 // ucd-generate 0.2.6 is available on crates.io.
 
 lazy_static! {

--- a/benches/tables/slice/general_categories.rs
+++ b/benches/tables/slice/general_categories.rs
@@ -2,6 +2,8 @@
 //
 //  ucd-generate general-category ./ucd-13.0.0 --exclude unassigned
 //
+// from UCD version 13.0.0.
+//
 // ucd-generate 0.2.6 is available on crates.io.
 
 pub const BY_NAME: &'static [(&'static str, &'static [(u32, u32)])] = &[

--- a/benches/tables/slice/general_category.rs
+++ b/benches/tables/slice/general_category.rs
@@ -2,6 +2,8 @@
 //
 //  ucd-generate general-category ./ucd-13.0.0 --exclude unassigned --enum
 //
+// from UCD version 13.0.0.
+//
 // ucd-generate 0.2.6 is available on crates.io.
 
 pub const GENERAL_CATEGORY_ENUM: &'static [&'static str] = &[

--- a/benches/tables/slice/jamo_short_name.rs
+++ b/benches/tables/slice/jamo_short_name.rs
@@ -2,6 +2,8 @@
 //
 //  ucd-generate jamo-short-name ./ucd-13.0.0
 //
+// from UCD version 13.0.0.
+//
 // ucd-generate 0.2.6 is available on crates.io.
 
 pub const JAMO_SHORT_NAME: &'static [(u32, &'static str)] = &[

--- a/benches/tables/slice/names.rs
+++ b/benches/tables/slice/names.rs
@@ -2,6 +2,8 @@
 //
 //  ucd-generate names ./ucd-13.0.0 --no-aliases --no-hangul --no-ideograph
 //
+// from UCD version 13.0.0.
+//
 // ucd-generate 0.2.6 is available on crates.io.
 
 pub const NAMES: &'static [(&'static str, u32)] = &[

--- a/benches/tables/trie/general_categories.rs
+++ b/benches/tables/trie/general_categories.rs
@@ -2,6 +2,8 @@
 //
 //  ucd-generate general-category ./ucd-13.0.0 --exclude unassigned --trie-set
 //
+// from UCD version 13.0.0.
+//
 // ucd-generate 0.2.6 is available on crates.io.
 
 pub const BY_NAME: &'static [(&'static str, &'static ::ucd_trie::TrieSet)] = &[

--- a/src/args.rs
+++ b/src/args.rs
@@ -38,6 +38,14 @@ impl<'a> ArgMatches<'a> {
         if let Some(p) = self.value_of_os("dfa-dir") {
             return builder.from_dfa_dir(p);
         }
+        // Some of the functionality of this crate works with a partial ucd
+        // directory.
+        match ucd_parse::ucd_directory_version(self.ucd_dir()?) {
+            Ok((major, minor, patch)) => {
+                builder.ucd_version(major, minor, patch)
+            }
+            Err(e) => return err!("Failed to determine UCD version: {}", e),
+        };
         match self.value_of_os("fst-dir") {
             None => Ok(builder.from_stdout()),
             Some(x) => builder.from_fst_dir(x),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -28,6 +28,7 @@ struct WriterOptions {
     fst_dir: Option<PathBuf>,
     trie_set: bool,
     dfa_dir: Option<PathBuf>,
+    ucd_version: Option<(u64, u64, u64)>,
 }
 
 impl WriterBuilder {
@@ -43,6 +44,7 @@ impl WriterBuilder {
             fst_dir: None,
             trie_set: false,
             dfa_dir: None,
+            ucd_version: None,
         })
     }
 
@@ -106,6 +108,16 @@ impl WriterBuilder {
     /// ranges.
     pub fn trie_set(&mut self, yes: bool) -> &mut WriterBuilder {
         self.0.trie_set = yes;
+        self
+    }
+    /// Set what version of the UCD we're generating data from.
+    pub fn ucd_version(
+        &mut self,
+        major: u64,
+        minor: u64,
+        patch: u64,
+    ) -> &mut WriterBuilder {
+        self.0.ucd_version = Some((major, minor, patch));
         self
     }
 }
@@ -1126,6 +1138,14 @@ impl Writer {
         writeln!(self.wtr, "//")?;
         writeln!(self.wtr, "//  {}", argv.join(" "))?;
         writeln!(self.wtr, "//")?;
+        if let Some((major, minor, patch)) = self.opts.ucd_version {
+            writeln!(
+                self.wtr,
+                "// from UCD version {}.{}.{}.",
+                major, minor, patch
+            )?;
+            writeln!(self.wtr, "//")?;
+        }
         writeln!(
             self.wtr,
             "// ucd-generate {} is available on crates.io.",

--- a/ucd-parse/src/common.rs
+++ b/ucd-parse/src/common.rs
@@ -73,6 +73,72 @@ where
     Ok(map)
 }
 
+/// Given a path pointing at the root of the `ucd_dir`, attempts to determine
+/// it's unicode version.
+///
+/// This just checks the readme and the very first line of PropList.txt -- in
+/// practice this works for all versions of UCD since 4.1.0.
+pub fn ucd_directory_version<D: ?Sized + AsRef<Path>>(
+    ucd_dir: &D,
+) -> Result<(u64, u64, u64), Error> {
+    // Avoid duplication from generic path parameter.
+    fn ucd_directory_version_inner(
+        ucd_dir: &Path,
+    ) -> Result<(u64, u64, u64), Error> {
+        lazy_static::lazy_static! {
+            static ref VERSION_RX: Regex =
+                Regex::new(r"-(\d+).(\d+).(\d+).txt").unwrap();
+        }
+        let proplist = ucd_dir.join("PropList.txt");
+        let contents = first_line(&proplist)?;
+
+        let caps = match VERSION_RX.captures(&contents) {
+            Some(c) => c,
+            None => {
+                return err!("Failed to find version in line {:?}", contents)
+            }
+        };
+
+        let num_capture = |n| {
+            caps.get(n).unwrap().as_str().parse::<u64>().map_err(|e| Error {
+                kind: ErrorKind::Parse(format!(
+                    "Failed to parse version from {:?}: {}",
+                    contents, e
+                )),
+                line: Some(0),
+                path: Some(proplist.clone()),
+            })
+        };
+
+        let major = num_capture(1)?;
+        let minor = num_capture(2)?;
+        let patch = num_capture(3)?;
+
+        Ok((major, minor, patch))
+    }
+    ucd_directory_version_inner(ucd_dir.as_ref())
+}
+
+fn first_line(path: &Path) -> Result<String, Error> {
+    let file = std::fs::File::open(path).map_err(|e| Error {
+        kind: ErrorKind::Io(e),
+        line: None,
+        path: Some(path.into()),
+    })?;
+
+    let mut reader = std::io::BufReader::new(file);
+    // In practice, this function is only used to read "# PropList-xx-y-z.txt"
+    // (21 bytes).
+    let mut line_contents = String::with_capacity(21);
+
+    reader.read_line(&mut line_contents).map_err(|e| Error {
+        kind: ErrorKind::Io(e),
+        line: None,
+        path: Some(path.into()),
+    })?;
+    Ok(line_contents)
+}
+
 /// A helper function for parsing a common record format that associates one
 /// or more codepoints with a string value.
 pub fn parse_codepoint_association<'a>(

--- a/ucd-parse/src/lib.rs
+++ b/ucd-parse/src/lib.rs
@@ -5,9 +5,9 @@ A library for parsing the Unicode character database.
 #![deny(missing_docs)]
 
 pub use crate::common::{
-    parse, parse_by_codepoint, parse_many_by_codepoint, Codepoint,
-    CodepointIter, CodepointRange, Codepoints, UcdFile, UcdFileByCodepoint,
-    UcdLineParser,
+    parse, parse_by_codepoint, parse_many_by_codepoint, ucd_directory_version,
+    Codepoint, CodepointIter, CodepointRange, Codepoints, UcdFile,
+    UcdFileByCodepoint, UcdLineParser,
 };
 pub use crate::error::{Error, ErrorKind};
 

--- a/ucd-trie/src/general_category.rs
+++ b/ucd-trie/src/general_category.rs
@@ -2,6 +2,8 @@
 //
 //  ucd-generate general-category ./ucd-13.0.0
 //
+// from UCD version 13.0.0.
+//
 // ucd-generate 0.2.6 is available on crates.io.
 
 pub const BY_NAME: &'static [(&'static str, &'static [(u32, u32)])] = &[

--- a/ucd-util/src/unicode_tables/jamo_short_name.rs
+++ b/ucd-util/src/unicode_tables/jamo_short_name.rs
@@ -2,6 +2,8 @@
 //
 //  ucd-generate jamo-short-name ./ucd-13.0.0
 //
+// from UCD version 13.0.0.
+//
 // ucd-generate 0.2.6 is available on crates.io.
 
 pub const JAMO_SHORT_NAME: &'static [(u32, &'static str)] = &[

--- a/ucd-util/src/unicode_tables/property_names.rs
+++ b/ucd-util/src/unicode_tables/property_names.rs
@@ -2,6 +2,8 @@
 //
 //  ucd-generate property-names ./ucd-13.0.0
 //
+// from UCD version 13.0.0.
+//
 // ucd-generate 0.2.6 is available on crates.io.
 
 pub const PROPERTY_NAMES: &'static [(&'static str, &'static str)] = &[

--- a/ucd-util/src/unicode_tables/property_values.rs
+++ b/ucd-util/src/unicode_tables/property_values.rs
@@ -2,6 +2,8 @@
 //
 //  ucd-generate property-values ./ucd-13.0.0
 //
+// from UCD version 13.0.0.
+//
 // ucd-generate 0.2.6 is available on crates.io.
 
 pub const PROPERTY_VALUES: &'static [(


### PR DESCRIPTION
I've wanted to do this a couple times but you mentioning it in #27 made me fish it out of `git stash` and finish it. It's a bit annoying since it's not actually included anywhere explicitly, but we read it out of a file that's been there for a long time and seems unlikely to go anywhere.