### PR TITLE
Add joining-group sub-command

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -57,6 +57,11 @@ script-extension produces one table of Unicode codepoint ranges for each
 possible Script_Extension value.
 ";
 
+const ABOUT_JOINING_GROUP: &'static str = "\
+joining-group produces one table of Unicode codepoint ranges for each
+possible Joining_Group value.
+";
+
 const ABOUT_JOINING_TYPE: &'static str = "\
 joining-type produces one table of Unicode codepoint ranges for each
 possible Joining_Type value.
@@ -350,6 +355,24 @@ pub fn app() -> App<'static, 'static> {
             "List the properties that can be generated with this \
              command.",
         ));
+    let cmd_joining_group = SubCommand::with_name("joining-group")
+        .author(clap::crate_authors!())
+        .version(clap::crate_version!())
+        .template(TEMPLATE_SUB)
+        .about("Create the Joining_Group property tables.")
+        .before_help(ABOUT_JOINING_GROUP)
+        .arg(ucd_dir.clone())
+        .arg(flag_fst_dir.clone())
+        .arg(flag_name("JOINING_GROUP"))
+        .arg(flag_chars.clone())
+        .arg(flag_trie_set.clone())
+        .arg(Arg::with_name("enum").long("enum").help(
+            "Emit a single table that maps codepoints to joining group.",
+        ))
+        .arg(Arg::with_name("rust-enum").long("rust-enum").help(
+            "Emit a Rust enum and a table that maps codepoints to \
+                 joining group.",
+        ));
     let cmd_joining_type =
         SubCommand::with_name("joining-type")
             .author(clap::crate_authors!())
@@ -636,6 +659,7 @@ pub fn app() -> App<'static, 'static> {
         .subcommand(cmd_general_category)
         .subcommand(cmd_script)
         .subcommand(cmd_script_extension)
+        .subcommand(cmd_joining_group)
         .subcommand(cmd_joining_type)
         .subcommand(cmd_age)
         .subcommand(cmd_bidi_mirroring_glyph)

--- a/src/joining_group.rs
+++ b/src/joining_group.rs
@@ -1,0 +1,50 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use ucd_parse::{self, ArabicShaping};
+
+use crate::args::ArgMatches;
+use crate::error::Result;
+use crate::util::PropertyValues;
+
+pub fn command(args: ArgMatches<'_>) -> Result<()> {
+    let dir = args.ucd_dir()?;
+    let propvals = PropertyValues::from_ucd_dir(&dir)?;
+    let rows: Vec<ArabicShaping> = ucd_parse::parse(&dir)?;
+
+    // Collect each joining group into an ordered set.
+    let mut by_group: BTreeMap<String, BTreeSet<u32>> = BTreeMap::new();
+    let mut assigned = BTreeSet::new();
+    for row in rows {
+        assigned.insert(row.codepoint.value());
+        let jg =
+            propvals.canonical("jg", row.joining_group.as_str())?.to_string();
+        by_group
+            .entry(jg)
+            .or_insert(BTreeSet::new())
+            .insert(row.codepoint.value());
+    }
+
+    // Process unassigned codepoints
+    let no_joining_group = propvals.canonical("jg", "no_joining_group")?;
+    for cp in 0..=0x10FFFF {
+        if assigned.contains(&cp) {
+            continue;
+        }
+        by_group.get_mut(&no_joining_group).unwrap().insert(cp);
+    }
+
+    let mut wtr = args.writer("joining_group")?;
+    if args.is_present("enum") {
+        wtr.ranges_to_enum(args.name(), &by_group)?;
+    } else if args.is_present("rust-enum") {
+        let variants = by_group.keys().map(String::as_str).collect::<Vec<_>>();
+        wtr.ranges_to_rust_enum(args.name(), &variants, &by_group)?;
+    } else {
+        wtr.names(by_group.keys())?;
+        for (name, set) in by_group {
+            wtr.ranges(&name, &set)?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ mod case_folding;
 mod case_mapping;
 mod general_category;
 mod jamo_short_name;
+mod joining_group;
 mod joining_type;
 mod names;
 mod property_bool;
@@ -65,6 +66,9 @@ fn run() -> Result<()> {
         }
         ("jamo-short-name", Some(m)) => {
             jamo_short_name::command(ArgMatches::new(m))
+        }
+        ("joining-group", Some(m)) => {
+            joining_group::command(ArgMatches::new(m))
         }
         ("joining-type", Some(m)) => joining_type::command(ArgMatches::new(m)),
         ("names", Some(m)) => names::command(ArgMatches::new(m)),

--- a/ucd-parse/src/arabic_shaping.rs
+++ b/ucd-parse/src/arabic_shaping.rs
@@ -24,7 +24,114 @@ pub struct ArabicShaping {
     /// The "joining type" of this codepoint.
     pub joining_type: JoiningType,
     /// The "joining group" of this codepoint.
-    pub joining_group: String,
+    pub joining_group: JoiningGroup,
+}
+
+/// The Joining_Group field read from ArabicShaping.txt
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum JoiningGroup {
+    AfricanFeh,
+    AfricanNoon,
+    AfricanQaf,
+    Ain,
+    Alaph,
+    Alef,
+    Beh,
+    Beth,
+    BurushaskiYehBarree,
+    Dal,
+    DalathRish,
+    E,
+    FarsiYeh,
+    Fe,
+    Feh,
+    FinalSemkath,
+    Gaf,
+    Gamal,
+    Hah,
+    HanifiRohingyaKinnaYa,
+    HanifiRohingyaPa,
+    He,
+    Heh,
+    HehGoal,
+    Heth,
+    Kaf,
+    Kaph,
+    Khaph,
+    KnottedHeh,
+    Lam,
+    Lamadh,
+    MalayalamBha,
+    MalayalamJa,
+    MalayalamLla,
+    MalayalamLlla,
+    MalayalamNga,
+    MalayalamNna,
+    MalayalamNnna,
+    MalayalamNya,
+    MalayalamRa,
+    MalayalamSsa,
+    MalayalamTta,
+    ManichaeanAleph,
+    ManichaeanAyin,
+    ManichaeanBeth,
+    ManichaeanDaleth,
+    ManichaeanDhamedh,
+    ManichaeanFive,
+    ManichaeanGimel,
+    ManichaeanHeth,
+    ManichaeanHundred,
+    ManichaeanKaph,
+    ManichaeanLamedh,
+    ManichaeanMem,
+    ManichaeanNun,
+    ManichaeanOne,
+    ManichaeanPe,
+    ManichaeanQoph,
+    ManichaeanResh,
+    ManichaeanSadhe,
+    ManichaeanSamekh,
+    ManichaeanTaw,
+    ManichaeanTen,
+    ManichaeanTeth,
+    ManichaeanThamedh,
+    ManichaeanTwenty,
+    ManichaeanWaw,
+    ManichaeanYodh,
+    ManichaeanZayin,
+    Meem,
+    Mim,
+    NoJoiningGroup,
+    Noon,
+    Nun,
+    Nya,
+    Pe,
+    Qaf,
+    Qaph,
+    Reh,
+    ReversedPe,
+    RohingyaYeh,
+    Sad,
+    Sadhe,
+    Seen,
+    Semkath,
+    Shin,
+    StraightWaw,
+    SwashKaf,
+    SyriacWaw,
+    Tah,
+    Taw,
+    TehMarbuta,
+    TehMarbutaGoal,
+    Teth,
+    Waw,
+    Yeh,
+    YehBarree,
+    YehWithTail,
+    Yudh,
+    YudhHe,
+    Zain,
+    Zhain,
 }
 
 /// The Joining_Type field read from ArabicShaping.txt
@@ -36,6 +143,235 @@ pub enum JoiningType {
     JoinCausing,
     NonJoining,
     Transparent,
+}
+
+impl JoiningGroup {
+    pub fn as_str(&self) -> &str {
+        match self {
+            JoiningGroup::AfricanFeh => "African_Feh",
+            JoiningGroup::AfricanNoon => "African_Noon",
+            JoiningGroup::AfricanQaf => "African_Qaf",
+            JoiningGroup::Ain => "Ain",
+            JoiningGroup::Alaph => "Alaph",
+            JoiningGroup::Alef => "Alef",
+            JoiningGroup::Beh => "Beh",
+            JoiningGroup::Beth => "Beth",
+            JoiningGroup::BurushaskiYehBarree => "Burushaski_Yeh_Barree",
+            JoiningGroup::Dal => "Dal",
+            JoiningGroup::DalathRish => "Dalath_Rish",
+            JoiningGroup::E => "E",
+            JoiningGroup::FarsiYeh => "Farsi_Yeh",
+            JoiningGroup::Fe => "Fe",
+            JoiningGroup::Feh => "Feh",
+            JoiningGroup::FinalSemkath => "Final_Semkath",
+            JoiningGroup::Gaf => "Gaf",
+            JoiningGroup::Gamal => "Gamal",
+            JoiningGroup::Hah => "Hah",
+            JoiningGroup::HanifiRohingyaKinnaYa => "Hanifi_Rohingya_Kinna_Ya",
+            JoiningGroup::HanifiRohingyaPa => "Hanifi_Rohingya_Pa",
+            JoiningGroup::He => "He",
+            JoiningGroup::Heh => "Heh",
+            JoiningGroup::HehGoal => "Heh_Goal",
+            JoiningGroup::Heth => "Heth",
+            JoiningGroup::Kaf => "Kaf",
+            JoiningGroup::Kaph => "Kaph",
+            JoiningGroup::Khaph => "Khaph",
+            JoiningGroup::KnottedHeh => "Knotted_Heh",
+            JoiningGroup::Lam => "Lam",
+            JoiningGroup::Lamadh => "Lamadh",
+            JoiningGroup::MalayalamBha => "Malayalam_Bha",
+            JoiningGroup::MalayalamJa => "Malayalam_Ja",
+            JoiningGroup::MalayalamLla => "Malayalam_Lla",
+            JoiningGroup::MalayalamLlla => "Malayalam_Llla",
+            JoiningGroup::MalayalamNga => "Malayalam_Nga",
+            JoiningGroup::MalayalamNna => "Malayalam_Nna",
+            JoiningGroup::MalayalamNnna => "Malayalam_Nnna",
+            JoiningGroup::MalayalamNya => "Malayalam_Nya",
+            JoiningGroup::MalayalamRa => "Malayalam_Ra",
+            JoiningGroup::MalayalamSsa => "Malayalam_Ssa",
+            JoiningGroup::MalayalamTta => "Malayalam_Tta",
+            JoiningGroup::ManichaeanAleph => "Manichaean_Aleph",
+            JoiningGroup::ManichaeanAyin => "Manichaean_Ayin",
+            JoiningGroup::ManichaeanBeth => "Manichaean_Beth",
+            JoiningGroup::ManichaeanDaleth => "Manichaean_Daleth",
+            JoiningGroup::ManichaeanDhamedh => "Manichaean_Dhamedh",
+            JoiningGroup::ManichaeanFive => "Manichaean_Five",
+            JoiningGroup::ManichaeanGimel => "Manichaean_Gimel",
+            JoiningGroup::ManichaeanHeth => "Manichaean_Heth",
+            JoiningGroup::ManichaeanHundred => "Manichaean_Hundred",
+            JoiningGroup::ManichaeanKaph => "Manichaean_Kaph",
+            JoiningGroup::ManichaeanLamedh => "Manichaean_Lamedh",
+            JoiningGroup::ManichaeanMem => "Manichaean_Mem",
+            JoiningGroup::ManichaeanNun => "Manichaean_Nun",
+            JoiningGroup::ManichaeanOne => "Manichaean_One",
+            JoiningGroup::ManichaeanPe => "Manichaean_Pe",
+            JoiningGroup::ManichaeanQoph => "Manichaean_Qoph",
+            JoiningGroup::ManichaeanResh => "Manichaean_Resh",
+            JoiningGroup::ManichaeanSadhe => "Manichaean_Sadhe",
+            JoiningGroup::ManichaeanSamekh => "Manichaean_Samekh",
+            JoiningGroup::ManichaeanTaw => "Manichaean_Taw",
+            JoiningGroup::ManichaeanTen => "Manichaean_Ten",
+            JoiningGroup::ManichaeanTeth => "Manichaean_Teth",
+            JoiningGroup::ManichaeanThamedh => "Manichaean_Thamedh",
+            JoiningGroup::ManichaeanTwenty => "Manichaean_Twenty",
+            JoiningGroup::ManichaeanWaw => "Manichaean_Waw",
+            JoiningGroup::ManichaeanYodh => "Manichaean_Yodh",
+            JoiningGroup::ManichaeanZayin => "Manichaean_Zayin",
+            JoiningGroup::Meem => "Meem",
+            JoiningGroup::Mim => "Mim",
+            JoiningGroup::NoJoiningGroup => "No_Joining_Group",
+            JoiningGroup::Noon => "Noon",
+            JoiningGroup::Nun => "Nun",
+            JoiningGroup::Nya => "Nya",
+            JoiningGroup::Pe => "Pe",
+            JoiningGroup::Qaf => "Qaf",
+            JoiningGroup::Qaph => "Qaph",
+            JoiningGroup::Reh => "Reh",
+            JoiningGroup::ReversedPe => "Reversed_Pe",
+            JoiningGroup::RohingyaYeh => "Rohingya_Yeh",
+            JoiningGroup::Sad => "Sad",
+            JoiningGroup::Sadhe => "Sadhe",
+            JoiningGroup::Seen => "Seen",
+            JoiningGroup::Semkath => "Semkath",
+            JoiningGroup::Shin => "Shin",
+            JoiningGroup::StraightWaw => "Straight_Waw",
+            JoiningGroup::SwashKaf => "Swash_Kaf",
+            JoiningGroup::SyriacWaw => "Syriac_Waw",
+            JoiningGroup::Tah => "Tah",
+            JoiningGroup::Taw => "Taw",
+            JoiningGroup::TehMarbuta => "Teh_Marbuta",
+            JoiningGroup::TehMarbutaGoal => "Teh_Marbuta_Goal",
+            JoiningGroup::Teth => "Teth",
+            JoiningGroup::Waw => "Waw",
+            JoiningGroup::Yeh => "Yeh",
+            JoiningGroup::YehBarree => "Yeh_Barree",
+            JoiningGroup::YehWithTail => "Yeh_With_Tail",
+            JoiningGroup::Yudh => "Yudh",
+            JoiningGroup::YudhHe => "Yudh_He",
+            JoiningGroup::Zain => "Zain",
+            JoiningGroup::Zhain => "Zhain",
+        }
+    }
+}
+
+impl FromStr for JoiningGroup {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<JoiningGroup, Error> {
+        match s {
+            "African_Feh" => Ok(JoiningGroup::AfricanFeh),
+            "African_Noon" => Ok(JoiningGroup::AfricanNoon),
+            "African_Qaf" => Ok(JoiningGroup::AfricanQaf),
+            "Ain" => Ok(JoiningGroup::Ain),
+            "Alaph" => Ok(JoiningGroup::Alaph),
+            "Alef" => Ok(JoiningGroup::Alef),
+            "Beh" => Ok(JoiningGroup::Beh),
+            "Beth" => Ok(JoiningGroup::Beth),
+            "Burushaski_Yeh_Barree" => Ok(JoiningGroup::BurushaskiYehBarree),
+            "Dal" => Ok(JoiningGroup::Dal),
+            "Dalath_Rish" => Ok(JoiningGroup::DalathRish),
+            "E" => Ok(JoiningGroup::E),
+            "Farsi_Yeh" => Ok(JoiningGroup::FarsiYeh),
+            "Fe" => Ok(JoiningGroup::Fe),
+            "Feh" => Ok(JoiningGroup::Feh),
+            "Final_Semkath" => Ok(JoiningGroup::FinalSemkath),
+            "Gaf" => Ok(JoiningGroup::Gaf),
+            "Gamal" => Ok(JoiningGroup::Gamal),
+            "Hah" => Ok(JoiningGroup::Hah),
+            "Hanifi_Rohingya_Kinna_Ya" => {
+                Ok(JoiningGroup::HanifiRohingyaKinnaYa)
+            }
+            "Hanifi_Rohingya_Pa" => Ok(JoiningGroup::HanifiRohingyaPa),
+            "He" => Ok(JoiningGroup::He),
+            "Heh" => Ok(JoiningGroup::Heh),
+            "Heh_Goal" => Ok(JoiningGroup::HehGoal),
+            "Heth" => Ok(JoiningGroup::Heth),
+            "Kaf" => Ok(JoiningGroup::Kaf),
+            "Kaph" => Ok(JoiningGroup::Kaph),
+            "Khaph" => Ok(JoiningGroup::Khaph),
+            "Knotted_Heh" => Ok(JoiningGroup::KnottedHeh),
+            "Lam" => Ok(JoiningGroup::Lam),
+            "Lamadh" => Ok(JoiningGroup::Lamadh),
+            "Malayalam_Bha" => Ok(JoiningGroup::MalayalamBha),
+            "Malayalam_Ja" => Ok(JoiningGroup::MalayalamJa),
+            "Malayalam_Lla" => Ok(JoiningGroup::MalayalamLla),
+            "Malayalam_Llla" => Ok(JoiningGroup::MalayalamLlla),
+            "Malayalam_Nga" => Ok(JoiningGroup::MalayalamNga),
+            "Malayalam_Nna" => Ok(JoiningGroup::MalayalamNna),
+            "Malayalam_Nnna" => Ok(JoiningGroup::MalayalamNnna),
+            "Malayalam_Nya" => Ok(JoiningGroup::MalayalamNya),
+            "Malayalam_Ra" => Ok(JoiningGroup::MalayalamRa),
+            "Malayalam_Ssa" => Ok(JoiningGroup::MalayalamSsa),
+            "Malayalam_Tta" => Ok(JoiningGroup::MalayalamTta),
+            "Manichaean_Aleph" => Ok(JoiningGroup::ManichaeanAleph),
+            "Manichaean_Ayin" => Ok(JoiningGroup::ManichaeanAyin),
+            "Manichaean_Beth" => Ok(JoiningGroup::ManichaeanBeth),
+            "Manichaean_Daleth" => Ok(JoiningGroup::ManichaeanDaleth),
+            "Manichaean_Dhamedh" => Ok(JoiningGroup::ManichaeanDhamedh),
+            "Manichaean_Five" => Ok(JoiningGroup::ManichaeanFive),
+            "Manichaean_Gimel" => Ok(JoiningGroup::ManichaeanGimel),
+            "Manichaean_Heth" => Ok(JoiningGroup::ManichaeanHeth),
+            "Manichaean_Hundred" => Ok(JoiningGroup::ManichaeanHundred),
+            "Manichaean_Kaph" => Ok(JoiningGroup::ManichaeanKaph),
+            "Manichaean_Lamedh" => Ok(JoiningGroup::ManichaeanLamedh),
+            "Manichaean_Mem" => Ok(JoiningGroup::ManichaeanMem),
+            "Manichaean_Nun" => Ok(JoiningGroup::ManichaeanNun),
+            "Manichaean_One" => Ok(JoiningGroup::ManichaeanOne),
+            "Manichaean_Pe" => Ok(JoiningGroup::ManichaeanPe),
+            "Manichaean_Qoph" => Ok(JoiningGroup::ManichaeanQoph),
+            "Manichaean_Resh" => Ok(JoiningGroup::ManichaeanResh),
+            "Manichaean_Sadhe" => Ok(JoiningGroup::ManichaeanSadhe),
+            "Manichaean_Samekh" => Ok(JoiningGroup::ManichaeanSamekh),
+            "Manichaean_Taw" => Ok(JoiningGroup::ManichaeanTaw),
+            "Manichaean_Ten" => Ok(JoiningGroup::ManichaeanTen),
+            "Manichaean_Teth" => Ok(JoiningGroup::ManichaeanTeth),
+            "Manichaean_Thamedh" => Ok(JoiningGroup::ManichaeanThamedh),
+            "Manichaean_Twenty" => Ok(JoiningGroup::ManichaeanTwenty),
+            "Manichaean_Waw" => Ok(JoiningGroup::ManichaeanWaw),
+            "Manichaean_Yodh" => Ok(JoiningGroup::ManichaeanYodh),
+            "Manichaean_Zayin" => Ok(JoiningGroup::ManichaeanZayin),
+            "Meem" => Ok(JoiningGroup::Meem),
+            "Mim" => Ok(JoiningGroup::Mim),
+            "No_Joining_Group" => Ok(JoiningGroup::NoJoiningGroup),
+            "Noon" => Ok(JoiningGroup::Noon),
+            "Nun" => Ok(JoiningGroup::Nun),
+            "Nya" => Ok(JoiningGroup::Nya),
+            "Pe" => Ok(JoiningGroup::Pe),
+            "Qaf" => Ok(JoiningGroup::Qaf),
+            "Qaph" => Ok(JoiningGroup::Qaph),
+            "Reh" => Ok(JoiningGroup::Reh),
+            "Reversed_Pe" => Ok(JoiningGroup::ReversedPe),
+            "Rohingya_Yeh" => Ok(JoiningGroup::RohingyaYeh),
+            "Sad" => Ok(JoiningGroup::Sad),
+            "Sadhe" => Ok(JoiningGroup::Sadhe),
+            "Seen" => Ok(JoiningGroup::Seen),
+            "Semkath" => Ok(JoiningGroup::Semkath),
+            "Shin" => Ok(JoiningGroup::Shin),
+            "Straight_Waw" => Ok(JoiningGroup::StraightWaw),
+            "Swash_Kaf" => Ok(JoiningGroup::SwashKaf),
+            "Syriac_Waw" => Ok(JoiningGroup::SyriacWaw),
+            "Tah" => Ok(JoiningGroup::Tah),
+            "Taw" => Ok(JoiningGroup::Taw),
+            "Teh_Marbuta" => Ok(JoiningGroup::TehMarbuta),
+            "Teh_Marbuta_Goal" => Ok(JoiningGroup::TehMarbutaGoal),
+            "Teth" => Ok(JoiningGroup::Teth),
+            "Waw" => Ok(JoiningGroup::Waw),
+            "Yeh" => Ok(JoiningGroup::Yeh),
+            "Yeh_Barree" => Ok(JoiningGroup::YehBarree),
+            "Yeh_With_Tail" => Ok(JoiningGroup::YehWithTail),
+            "Yudh" => Ok(JoiningGroup::Yudh),
+            "Yudh_He" => Ok(JoiningGroup::YudhHe),
+            "Zain" => Ok(JoiningGroup::Zain),
+            "Zhain" => Ok(JoiningGroup::Zhain),
+            _ => err!("unrecognized joining group: '{}'", s),
+        }
+    }
+}
+
+impl Default for JoiningGroup {
+    fn default() -> JoiningGroup {
+        JoiningGroup::NoJoiningGroup
+    }
 }
 
 impl JoiningType {
@@ -115,9 +451,31 @@ impl FromStr for ArabicShaping {
             codepoint: caps["codepoint"].parse()?,
             schematic_name: caps["name"].to_string(),
             joining_type: caps["joining_type"].parse()?,
-            joining_group: caps["joining_group"].to_string(),
+            joining_group: formal_name(&caps["joining_group"]).parse()?,
         })
     }
+}
+
+// For whatever reason the "formal" Joining_Group property name is not stored
+// in the file. Instead the value is based on the schematic_name (all
+// uppercase, space separated). This function transforms those into the formal
+// form, as present in PropertyValueAliases.txt.
+fn formal_name(s: &str) -> String {
+    // Convert to Pascal_Snake_Case
+    s.split(|c: char| c.is_whitespace() || c == '_')
+        .map(|component| {
+            // Upper first char
+            let lower = component.to_ascii_lowercase();
+            let mut chars = lower.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(f) => {
+                    f.to_uppercase().collect::<String>() + chars.as_str()
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("_")
 }
 
 #[cfg(test)]
@@ -125,6 +483,7 @@ mod tests {
     use crate::common::Codepoint;
 
     use super::{ArabicShaping, JoiningType};
+    use crate::arabic_shaping::JoiningGroup;
 
     fn codepoint(n: u32) -> Codepoint {
         Codepoint::from_u32(n).unwrap()
@@ -144,7 +503,7 @@ mod tests {
                 codepoint: codepoint(0x0600),
                 schematic_name: s("ARABIC NUMBER SIGN"),
                 joining_type: JoiningType::NonJoining,
-                joining_group: s("No_Joining_Group")
+                joining_group: JoiningGroup::NoJoiningGroup,
             }
         );
     }
@@ -159,7 +518,7 @@ mod tests {
                 codepoint: codepoint(0x063D),
                 schematic_name: s("FARSI YEH WITH INVERTED V ABOVE"),
                 joining_type: JoiningType::DualJoining,
-                joining_group: s("FARSI YEH")
+                joining_group: JoiningGroup::FarsiYeh,
             }
         );
     }
@@ -177,7 +536,7 @@ mod tests {
                     "HANIFI ROHINGYA DOTLESS KINNA YA WITH DOT ABOVE"
                 ),
                 joining_type: JoiningType::DualJoining,
-                joining_group: s("HANIFI ROHINGYA KINNA YA")
+                joining_group: JoiningGroup::HanifiRohingyaKinnaYa,
             }
         );
     }


### PR DESCRIPTION
This PR adds a `joining-group` sub-command that exposes the field of the same name from `ArabicShaping.txt`.

There is an initial commit that changes the `joining-group` field on `ArabicShaping` from a `String` to and enum. 

This field is a little weird in that it's stored in `ArabicShaping.txt` in a different form to the "formal" form in `PropertyValueAliases.txt`. As a result there is a function to convert from the input ArabicShaping form to the PropertyValueAliases form. The enum and associated methods are implmented in terms of the PropertyValueAliases form.

For example in this row:

    0629; TEH MARBUTA; R; TEH MARBUTA

`TEH MARBUTA` (last field) corresponds to `Joining_Group` `Teh_Marbuta`.

**Sample output:**

```rust
// DO NOT EDIT THIS FILE. IT WAS AUTOMATICALLY GENERATED BY:
//
//   ucd-generate joining-group --rust-enum /home/wmoore/Downloads/ucd-13.0
//
// Unicode version: 13.0.0.
//
// ucd-generate 0.2.8 is available on crates.io.

#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
pub enum JoiningGroup {
  AfricanFeh, AfricanNoon, AfricanQaf, Ain, Alaph, Alef, Beh, Beth,
  BurushaskiYehBarree, Dal, DalathRish, E, FarsiYeh, Fe, Feh, FinalSemkath,
  Gaf, Gamal, Hah, HamzaOnHehGoal, HanifiRohingyaKinnaYa, HanifiRohingyaPa,
  He, Heh, HehGoal, Heth, Kaf, Kaph, Khaph, KnottedHeh, Lam, Lamadh,
  MalayalamBha, MalayalamJa, MalayalamLla, MalayalamLlla, MalayalamNga,
  MalayalamNna, MalayalamNnna, MalayalamNya, MalayalamRa, MalayalamSsa,
  MalayalamTta, ManichaeanAleph, ManichaeanAyin, ManichaeanBeth,
  ManichaeanDaleth, ManichaeanDhamedh, ManichaeanFive, ManichaeanGimel,
  ManichaeanHeth, ManichaeanHundred, ManichaeanKaph, ManichaeanLamedh,
  ManichaeanMem, ManichaeanNun, ManichaeanOne, ManichaeanPe, ManichaeanQoph,
  ManichaeanResh, ManichaeanSadhe, ManichaeanSamekh, ManichaeanTaw,
  ManichaeanTen, ManichaeanTeth, ManichaeanThamedh, ManichaeanTwenty,
  ManichaeanWaw, ManichaeanYodh, ManichaeanZayin, Meem, Mim, NoJoiningGroup,
  Noon, Nun, Nya, Pe, Qaf, Qaph, Reh, ReversedPe, RohingyaYeh, Sad, Sadhe,
  Seen, Semkath, Shin, StraightWaw, SwashKaf, SyriacWaw, Tah, Taw, TehMarbuta,
  Teth, Waw, Yeh, YehBarree, YehWithTail, Yudh, YudhHe, Zain, Zhain,
}

pub const JOINING_GROUP: &'static [(u32, u32, JoiningGroup)] = &[
  (0, 1567, JoiningGroup::NoJoiningGroup), (1568, 1568, JoiningGroup::Yeh),
  (1569, 1569, JoiningGroup::NoJoiningGroup),
  (1570, 1571, JoiningGroup::Alef), (1572, 1572, JoiningGroup::Waw),
  (1573, 1573, JoiningGroup::Alef), (1574, 1574, JoiningGroup::Yeh),
  (1575, 1575, JoiningGroup::Alef), (1576, 1576, JoiningGroup::Beh),
  (1577, 1577, JoiningGroup::TehMarbuta), (1578, 1579, JoiningGroup::Beh),
  ⋮
  (68900, 1114111, JoiningGroup::NoJoiningGroup),
];
```