### PR TITLE
Add support for emitting flattened case tables

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -196,10 +196,16 @@ pub fn app() -> App<'static, 'static> {
         .long("fst-dir")
         .help("Emit the table as a FST in Rust source code.")
         .takes_value(true);
+    let flag_flat_table = Arg::with_name("flat-table").long("flat-table").help(
+        "When emitting a map of a single codepoint to multiple codepoints, emit \
+         entries as `(u32, [u32; 3])` instead of as `(u32, &[u32])` (replacing \
+         `u32` with `char` if `--chars` is passed). \
+         Conceptually unoccupied indices of the array will contain `!0u32` (for \
+         u32) or `\\u{0}` (for `char`)."
+    );
     let ucd_dir = Arg::with_name("ucd-dir")
         .required(true)
         .help("Directory containing the Unicode character database files.");
-
     // Subcommands.
     let cmd_bidi_class = SubCommand::with_name("bidi-class")
         .author(clap::crate_authors!())
@@ -506,7 +512,8 @@ pub fn app() -> App<'static, 'static> {
         .arg(Arg::with_name("all-pairs").long("all-pairs").help(
             "Emit a table where each codepoint includes all possible \
              Simple mappings.",
-        ));
+        ))
+        .arg(flag_flat_table.clone().requires("all-pairs"));
     let cmd_case_mapping = SubCommand::with_name("case-mapping")
         .author(clap::crate_authors!())
         .version(clap::crate_version!())
@@ -520,7 +527,8 @@ pub fn app() -> App<'static, 'static> {
             "Only emit the simple case mapping tables \
              (emit maps of codepoint to codepoint, \
              ignoring rules from SpecialCasing.txt)",
-        ));
+        ))
+        .arg(flag_flat_table.clone().conflicts_with("simple"));
 
     let cmd_grapheme_cluster_break =
         SubCommand::with_name("grapheme-cluster-break")

--- a/src/case_folding.rs
+++ b/src/case_folding.rs
@@ -67,7 +67,8 @@ pub fn command(args: ArgMatches<'_>) -> Result<()> {
         }
         wtr.codepoint_to_codepoint(args.name(), &equiv)?;
     } else if args.is_present("all-pairs") {
-        wtr.multi_codepoint_to_codepoint(args.name(), &table_all)?;
+        let flat = args.is_present("flat-table");
+        wtr.multi_codepoint_to_codepoint(args.name(), &table_all, flat)?;
     } else {
         wtr.codepoint_to_codepoint(args.name(), &table)?;
     }

--- a/src/case_mapping.rs
+++ b/src/case_mapping.rs
@@ -60,9 +60,10 @@ pub fn command(args: ArgMatches<'_>) -> Result<()> {
                 );
             }
         }
-        wtr.codepoint_to_codepoints("LOWER", &lower_map)?;
-        wtr.codepoint_to_codepoints("UPPER", &upper_map)?;
-        wtr.codepoint_to_codepoints("TITLE", &upper_map)?;
+        let flat = args.is_present("flat-table");
+        wtr.codepoint_to_codepoints("LOWER", &lower_map, flat)?;
+        wtr.codepoint_to_codepoints("UPPER", &upper_map, flat)?;
+        wtr.codepoint_to_codepoints("TITLE", &upper_map, flat)?;
     }
     Ok(())
 }


### PR DESCRIPTION
Fixes #33, which is where you should look for far too many words describing this.

Ideally we'd somehow deprecate the old version -- I don't think there's any case where it's better except for being arguably a little cleaner, and IMO defaulting to a larger, less efficient format isn't really great, even if it does avoid being a breaking change.

I'm willing to change name/description/etc of stuff -- I don't have an opinion really.