### PR TITLE
Add --combined option

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -199,9 +199,12 @@ pub fn app() -> App<'static, 'static> {
     let ucd_dir = Arg::with_name("ucd-dir")
         .required(true)
         .help("Directory containing the Unicode character database files.");
-    let flag_combined = Arg::with_name("combined")
-        .long("combined")
-        .help("Emit a single table with all included codepoint ranges.");
+    let flag_combined = Arg::with_name("combined").long("combined").help(
+        "Emit a single table with all included codepoint ranges. You might \
+        want to use this option when checking if characters belong to a \
+        subset of categories, since only one table will need to be checked. \
+        Searching the combined table should be simpler and more efficient.",
+    );
 
     // Subcommands.
     let cmd_bidi_class = SubCommand::with_name("bidi-class")

--- a/src/app.rs
+++ b/src/app.rs
@@ -222,6 +222,11 @@ pub fn app() -> App<'static, 'static> {
             "Emit a Rust enum and a table that maps codepoints to bidi class.",
         ))
         .arg(
+            Arg::with_name("combined").long("combined").help(
+                "Emit a single table with all included codepoint ranges.",
+            ),
+        )
+        .arg(
             Arg::with_name("list-classes")
                 .long("list-classes")
                 .help("List all of the bidi class names with abbreviations."),
@@ -260,6 +265,11 @@ pub fn app() -> App<'static, 'static> {
         .arg(Arg::with_name("rust-enum").long("rust-enum").help(
             "Emit a Rust enum and a table that maps codepoints to categories.",
         ))
+        .arg(
+            Arg::with_name("combined").long("combined").help(
+                "Emit a single table with all included codepoint ranges.",
+            ),
+        )
         .arg(Arg::with_name("include").long("include").takes_value(true).help(
             "A comma separated list of categories to include. \
              When absent, all categories are included.",
@@ -293,6 +303,11 @@ pub fn app() -> App<'static, 'static> {
         .arg(Arg::with_name("rust-enum").long("rust-enum").help(
             "Emit a Rust enum and a table that maps codepoints to scripts.",
         ))
+        .arg(
+            Arg::with_name("combined").long("combined").help(
+                "Emit a single table with all included codepoint ranges.",
+            ),
+        )
         .arg(Arg::with_name("include").long("include").takes_value(true).help(
             "A comma separated list of scripts to include. \
              When absent, all scripts are included.",
@@ -368,6 +383,9 @@ pub fn app() -> App<'static, 'static> {
             .arg(Arg::with_name("rust-enum").long("rust-enum").help(
                 "Emit a Rust enum and a table that maps codepoints to \
                  joining type.",
+            ))
+            .arg(Arg::with_name("combined").long("combined").help(
+                "Emit a single table with all included codepoint ranges.",
             ));
     let cmd_prop_bool = SubCommand::with_name("property-bool")
         .author(clap::crate_authors!())

--- a/src/app.rs
+++ b/src/app.rs
@@ -199,6 +199,9 @@ pub fn app() -> App<'static, 'static> {
     let ucd_dir = Arg::with_name("ucd-dir")
         .required(true)
         .help("Directory containing the Unicode character database files.");
+    let flag_combined = Arg::with_name("combined")
+        .long("combined")
+        .help("Emit a single table with all included codepoint ranges.");
 
     // Subcommands.
     let cmd_bidi_class = SubCommand::with_name("bidi-class")
@@ -213,6 +216,7 @@ pub fn app() -> App<'static, 'static> {
         .arg(flag_chars.clone())
         .arg(flag_trie_set.clone())
         .arg(flag_short_names.clone())
+        .arg(flag_combined.clone())
         .arg(
             Arg::with_name("enum").long("enum").help(
                 "Emit a single table that maps codepoints to bidi class.",
@@ -221,11 +225,6 @@ pub fn app() -> App<'static, 'static> {
         .arg(Arg::with_name("rust-enum").long("rust-enum").help(
             "Emit a Rust enum and a table that maps codepoints to bidi class.",
         ))
-        .arg(
-            Arg::with_name("combined").long("combined").help(
-                "Emit a single table with all included codepoint ranges.",
-            ),
-        )
         .arg(
             Arg::with_name("list-classes")
                 .long("list-classes")
@@ -257,6 +256,7 @@ pub fn app() -> App<'static, 'static> {
         .arg(flag_name("GENERAL_CATEGORY"))
         .arg(flag_chars.clone())
         .arg(flag_trie_set.clone())
+        .arg(flag_combined.clone())
         .arg(
             Arg::with_name("enum").long("enum").help(
                 "Emit a single table that maps codepoints to categories.",
@@ -265,11 +265,6 @@ pub fn app() -> App<'static, 'static> {
         .arg(Arg::with_name("rust-enum").long("rust-enum").help(
             "Emit a Rust enum and a table that maps codepoints to categories.",
         ))
-        .arg(
-            Arg::with_name("combined").long("combined").help(
-                "Emit a single table with all included codepoint ranges.",
-            ),
-        )
         .arg(Arg::with_name("include").long("include").takes_value(true).help(
             "A comma separated list of categories to include. \
              When absent, all categories are included.",
@@ -295,6 +290,7 @@ pub fn app() -> App<'static, 'static> {
         .arg(flag_name("SCRIPT"))
         .arg(flag_chars.clone())
         .arg(flag_trie_set.clone())
+        .arg(flag_combined.clone())
         .arg(
             Arg::with_name("enum")
                 .long("enum")
@@ -303,11 +299,6 @@ pub fn app() -> App<'static, 'static> {
         .arg(Arg::with_name("rust-enum").long("rust-enum").help(
             "Emit a Rust enum and a table that maps codepoints to scripts.",
         ))
-        .arg(
-            Arg::with_name("combined").long("combined").help(
-                "Emit a single table with all included codepoint ranges.",
-            ),
-        )
         .arg(Arg::with_name("include").long("include").takes_value(true).help(
             "A comma separated list of scripts to include. \
              When absent, all scripts are included.",
@@ -377,15 +368,13 @@ pub fn app() -> App<'static, 'static> {
             .arg(flag_name("JOINING_TYPE"))
             .arg(flag_chars.clone())
             .arg(flag_trie_set.clone())
+            .arg(flag_combined.clone())
             .arg(Arg::with_name("enum").long("enum").help(
                 "Emit a single table that maps codepoints to joining type.",
             ))
             .arg(Arg::with_name("rust-enum").long("rust-enum").help(
                 "Emit a Rust enum and a table that maps codepoints to \
                  joining type.",
-            ))
-            .arg(Arg::with_name("combined").long("combined").help(
-                "Emit a single table with all included codepoint ranges.",
             ));
     let cmd_prop_bool = SubCommand::with_name("property-bool")
         .author(clap::crate_authors!())

--- a/src/bidi_class.rs
+++ b/src/bidi_class.rs
@@ -140,6 +140,8 @@ pub fn command(args: ArgMatches<'_>) -> Result<()> {
     } else if args.is_present("rust-enum") {
         let variants = by_type.keys().map(String::as_str).collect::<Vec<_>>();
         wtr.ranges_to_rust_enum(args.name(), &variants, &by_type)?;
+    } else if args.is_present("combined") {
+        wtr.ranges_to_combined(args.name(), &by_type)?;
     } else {
         wtr.names(by_type.keys())?;
         for (name, set) in by_type {

--- a/src/general_category.rs
+++ b/src/general_category.rs
@@ -43,6 +43,8 @@ pub fn command(args: ArgMatches<'_>) -> Result<()> {
     } else if args.is_present("rust-enum") {
         let variants = bycat.keys().map(String::as_str).collect::<Vec<_>>();
         wtr.ranges_to_rust_enum(args.name(), &variants, &bycat)?;
+    } else if args.is_present("combined") {
+        wtr.ranges_to_combined(args.name(), &bycat)?;
     } else {
         wtr.names(bycat.keys().filter(|n| filter.contains(n)))?;
         for (name, set) in bycat {

--- a/src/joining_type.rs
+++ b/src/joining_type.rs
@@ -62,6 +62,8 @@ pub fn command(args: ArgMatches<'_>) -> Result<()> {
     } else if args.is_present("rust-enum") {
         let variants = by_type.keys().map(String::as_str).collect::<Vec<_>>();
         wtr.ranges_to_rust_enum(args.name(), &variants, &by_type)?;
+    } else if args.is_present("combined") {
+        wtr.ranges_to_combined(args.name(), &by_type)?;
     } else {
         wtr.names(by_type.keys())?;
         for (name, set) in by_type {

--- a/src/script.rs
+++ b/src/script.rs
@@ -31,6 +31,8 @@ pub fn command_script(args: ArgMatches<'_>) -> Result<()> {
         let mut variants = vec!["Unknown"];
         variants.extend(by_name.keys().map(String::as_str));
         wtr.ranges_to_rust_enum(args.name(), &variants, &by_name)?;
+    } else if args.is_present("combined") {
+        wtr.ranges_to_combined(args.name(), &by_name)?;
     } else {
         wtr.names(by_name.keys().filter(|n| filter.contains(n)))?;
         for (name, set) in by_name {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -330,6 +330,24 @@ impl Writer {
         Ok(())
     }
 
+    /// Write a map that combines codepoint ranges into a single table.
+    ///
+    /// The given map should be a map from the variant value to the set of
+    /// codepoints that have that value.
+    pub fn ranges_to_combined(
+        &mut self,
+        name: &str,
+        enum_map: &BTreeMap<String, BTreeSet<u32>>,
+    ) -> Result<()> {
+        let mut set = Vec::new();
+        for other_set in enum_map.values() {
+            set.extend(other_set.iter().cloned());
+        }
+        self.range_set(name, &set)?;
+        self.wtr.flush()?;
+        Ok(())
+    }
+
     fn ranges_to_enum_slice<S>(
         &mut self,
         name: &str,
@@ -390,6 +408,29 @@ impl Writer {
         Ok(())
     }
 
+    /// Write a set that contains ranges of codepoints.
+    ///
+    /// The smallest numeric type is used when applicable.
+    pub fn range_set(&mut self, name: &str, set: &[u32]) -> Result<()> {
+        self.header()?;
+        self.separator()?;
+
+        let name = rust_const_name(name);
+        if self.opts.fst_dir.is_some() {
+            let mut builder = SetBuilder::memory();
+            for &k in set {
+                builder.insert(u32_key(k))?;
+            }
+            let set = builder.into_set();
+            self.fst(&name, set.as_fst(), false)?;
+        } else {
+            let ranges = util::to_ranges(set.iter().cloned());
+            self.range_set_slice(&name, &ranges)?;
+        }
+        self.wtr.flush()?;
+        Ok(())
+    }
+
     fn ranges_to_unsigned_integer_slice(
         &mut self,
         name: &str,
@@ -410,6 +451,29 @@ impl Writer {
             let range = (self.rust_codepoint(start), self.rust_codepoint(end));
             if let (Some(start), Some(end)) = range {
                 let src = format!("({}, {}, {}), ", start, end, num);
+                self.wtr.write_str(&src)?;
+            }
+        }
+        writeln!(self.wtr, "];")?;
+        Ok(())
+    }
+
+    fn range_set_slice(
+        &mut self,
+        name: &str,
+        table: &[(u32, u32)],
+    ) -> Result<()> {
+        let cp_ty = self.rust_codepoint_type();
+
+        writeln!(
+            self.wtr,
+            "pub const {}: &'static [({}, {})] = &[",
+            name, cp_ty, cp_ty
+        )?;
+        for &(start, end) in table {
+            let range = (self.rust_codepoint(start), self.rust_codepoint(end));
+            if let (Some(start), Some(end)) = range {
+                let src = format!("({}, {}), ", start, end);
                 self.wtr.write_str(&src)?;
             }
         }


### PR DESCRIPTION
Thanks for creating this very useful crate.

This adds a `--combined` option that works the same way as not adding the option, except all tables are combined into a single table. It can create smaller tables than `--enum` when it's only necessary to check if a code point is part of any variant.

It also supports related categories, which [`--enum` doesn't](https://github.com/BurntSushi/ucd-generate/blob/483d7d5b9f734275ee39b1670e659916eea8d132/src/general_category.rs#L23-L33).