### PR TITLE
Fix bug in output of title case mapping

### DIFF
--- a/src/case_mapping.rs
+++ b/src/case_mapping.rs
@@ -62,7 +62,7 @@ pub fn command(args: ArgMatches<'_>) -> Result<()> {
         }
         wtr.codepoint_to_codepoints("LOWER", &lower_map)?;
         wtr.codepoint_to_codepoints("UPPER", &upper_map)?;
-        wtr.codepoint_to_codepoints("TITLE", &upper_map)?;
+        wtr.codepoint_to_codepoints("TITLE", &title_map)?;
     }
     Ok(())
 }


### PR DESCRIPTION
The `case-mapping` sub-command introduced in #17 outputs the upper-case mapping for the `TITLE` table instead of the title-case mapping. This PR fixes the bug.