### PR TITLE
Add canonical-combining-class sub-command

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -47,6 +47,11 @@ general-category produces one table of Unicode codepoint ranges for each
 possible General_Category value.
 ";
 
+const ABOUT_CANONICAL_COMBINING_CLASS: &'static str = "\
+canonical-combining-class produces one table of Unicode codepoint ranges for
+each possible Canonical_Combining_Class value.
+";
+
 const ABOUT_SCRIPT: &'static str = "\
 script produces one table of Unicode codepoint ranges for each possible Script
 value.
@@ -282,6 +287,30 @@ pub fn app() -> App<'static, 'static> {
                 .long("list-categories")
                 .help("List all of the category names with abbreviations."),
         );
+    let cmd_canonical_combining_class =
+        SubCommand::with_name("canonical-combining-class")
+            .author(clap::crate_authors!())
+            .version(clap::crate_version!())
+            .template(TEMPLATE_SUB)
+            .about("Create the Canonical_Combining_Class table.")
+            .before_help(ABOUT_CANONICAL_COMBINING_CLASS)
+            .arg(ucd_dir.clone())
+            .arg(flag_fst_dir.clone())
+            .arg(flag_name("CANONICAL_COMBINING_CLASS"))
+            .arg(flag_chars.clone())
+            .arg(flag_trie_set.clone())
+            .arg(Arg::with_name("enum").long("enum").help(
+                "Emit a single table that maps codepoints to canonical \
+                 combining class.",
+            ))
+            .arg(Arg::with_name("rust-enum").long("rust-enum").help(
+                "Emit a Rust enum and a table that maps codepoints to \
+                 canonical combining class.",
+            ))
+            .arg(Arg::with_name("list-classes").long("list-classes").help(
+                "List all of the canonical combining class names with \
+                 abbreviations.",
+            ));
     let cmd_script = SubCommand::with_name("script")
         .author(clap::crate_authors!())
         .version(clap::crate_version!())
@@ -644,6 +673,7 @@ pub fn app() -> App<'static, 'static> {
         .setting(AppSettings::UnifiedHelpMessage)
         .subcommand(cmd_bidi_class)
         .subcommand(cmd_general_category)
+        .subcommand(cmd_canonical_combining_class)
         .subcommand(cmd_script)
         .subcommand(cmd_script_extension)
         .subcommand(cmd_joining_type)

--- a/src/canonical_combining_class.rs
+++ b/src/canonical_combining_class.rs
@@ -1,0 +1,61 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use ucd_parse::{self, UnicodeData};
+
+use crate::args::ArgMatches;
+use crate::error::Result;
+use crate::util::{print_property_values, PropertyValues};
+
+pub fn command(args: ArgMatches<'_>) -> Result<()> {
+    let dir = args.ucd_dir()?;
+    let propvals = PropertyValues::from_ucd_dir(&dir)?;
+    let rows: Vec<UnicodeData> = ucd_parse::parse(&dir)?;
+    let ccc_name = |ccc: u8| {
+        propvals.canonical("canonicalcombiningclass", &ccc.to_string())
+    };
+
+    // If we were tasked with listing the available categories, then do that
+    // and quit.
+    if args.is_present("list-classes") {
+        return print_property_values(&propvals, "Canonical_Combining_Class");
+    }
+
+    // Collect each canonical combining class into an ordered set.
+    let mut by_name: BTreeMap<String, BTreeSet<u32>> = BTreeMap::new();
+    let mut assigned = BTreeSet::new();
+    for row in rows {
+        assigned.insert(row.codepoint.value());
+        let ccc = ccc_name(row.canonical_combining_class)?;
+        by_name
+            .entry(ccc)
+            .or_insert(BTreeSet::new())
+            .insert(row.codepoint.value());
+    }
+
+    // Process the codepoints that are not listed as per the note in
+    // DerivedCombiningClass.txt (UCD 13.0):
+    //
+    // - All code points not explicitly listed for Canonical_Combining_Class
+    //   have the value Not_Reordered (0).
+    let not_reordered_name = ccc_name(0)?;
+    for cp in 0..=0x10FFFF {
+        if !assigned.contains(&cp) {
+            by_name.get_mut(&not_reordered_name).unwrap().insert(cp);
+        }
+    }
+
+    let mut wtr = args.writer("canonical_combining_class")?;
+    if args.is_present("enum") {
+        wtr.ranges_to_enum(args.name(), &by_name)?;
+    } else if args.is_present("rust-enum") {
+        let variants = by_name.keys().map(String::as_str).collect::<Vec<_>>();
+        wtr.ranges_to_rust_enum(args.name(), &variants, &by_name)?;
+    } else {
+        wtr.names(by_name.keys())?;
+        for (name, set) in by_name {
+            wtr.ranges(&name, &set)?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod age;
 mod bidi_class;
 mod bidi_mirroring_glyph;
 mod brk;
+mod canonical_combining_class;
 mod case_folding;
 mod case_mapping;
 mod general_category;
@@ -48,6 +49,9 @@ fn run() -> Result<()> {
         ("bidi-class", Some(m)) => bidi_class::command(ArgMatches::new(m)),
         ("bidi-mirroring-glyph", Some(m)) => {
             bidi_mirroring_glyph::command(ArgMatches::new(m))
+        }
+        ("canonical-combining-class", Some(m)) => {
+            canonical_combining_class::command(ArgMatches::new(m))
         }
         ("general-category", Some(m)) => {
             general_category::command(ArgMatches::new(m))


### PR DESCRIPTION
Adds support for generating Rust enums with custom discriminants, en route. This was to allow ordering of the `Canonical_Combining_Class` values.