### PR TITLE
cli: Derive Ord and PartialOrd for enums with custom discriminant values

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -349,7 +349,7 @@ impl Writer {
 
         writeln!(
             self.wtr,
-            "#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]",
+            "#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]",
         )?;
         let enum_name = rust_type_name(name);
         writeln!(self.wtr, "pub enum {} {{", enum_name)?;


### PR DESCRIPTION
Hello again @BurntSushi,

This is a follow-up to #45, and was made in response to [a recent issue](https://github.com/yeslogic/unicode-canonical-combining-class/issues/3).

The rationale for adding the `Ord` and `PartialOrd` derives is for convenience, instead of having to cast the generated enums to their discriminant values for purposes of ordering.