### PR TITLE
Replace lazy_static dependency with once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,10 +33,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
+name = "once_cell"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "regex"
@@ -84,7 +84,7 @@ dependencies = [
  "byteorder",
  "clap",
  "fst",
- "lazy_static",
+ "once_cell",
  "regex-automata",
  "ucd-parse",
  "ucd-trie",
@@ -95,7 +95,7 @@ dependencies = [
 name = "ucd-parse"
 version = "0.1.9"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "regex",
 ]
 
@@ -103,7 +103,7 @@ dependencies = [
 name = "ucd-trie"
 version = "0.1.4"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default-features = false
 features = ["suggestions"]
 
 [dev-dependencies]
-lazy_static = "1"
+once_cell = "1"
 
 [profile.release]
 debug = true

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,7 +1,5 @@
 #![feature(test)]
 
-#[macro_use]
-extern crate lazy_static;
 extern crate test;
 
 use std::cmp::Ordering;

--- a/benches/tables/fst/general_category.rs
+++ b/benches/tables/fst/general_category.rs
@@ -38,8 +38,11 @@ pub const GENERAL_CATEGORY_ENUM: &'static [&'static str] = &[
     "Uppercase_Letter",
 ];
 
-lazy_static::lazy_static! {
-  pub static ref GENERAL_CATEGORY: ::fst::Map<&'static [u8]> =
-    ::fst::Map::from(::fst::raw::Fst::new(
-      &include_bytes!("general_category.fst")[..]).unwrap());
-}
+pub static GENERAL_CATEGORY: ::once_cell::sync::Lazy<
+    ::fst::Map<&'static [u8]>,
+> = ::once_cell::sync::Lazy::new(|| {
+    ::fst::Map::from(
+        ::fst::raw::Fst::new(&include_bytes!("general_category.fst")[..])
+            .unwrap(),
+    )
+});

--- a/benches/tables/fst/jamo_short_name.rs
+++ b/benches/tables/fst/jamo_short_name.rs
@@ -6,8 +6,11 @@
 //
 // ucd-generate 0.2.10 is available on crates.io.
 
-lazy_static::lazy_static! {
-  pub static ref JAMO_SHORT_NAME: ::fst::Map<&'static [u8]> =
-    ::fst::Map::from(::fst::raw::Fst::new(
-      &include_bytes!("jamo_short_name.fst")[..]).unwrap());
-}
+pub static JAMO_SHORT_NAME: ::once_cell::sync::Lazy<
+    ::fst::Map<&'static [u8]>,
+> = ::once_cell::sync::Lazy::new(|| {
+    ::fst::Map::from(
+        ::fst::raw::Fst::new(&include_bytes!("jamo_short_name.fst")[..])
+            .unwrap(),
+    )
+});

--- a/benches/tables/fst/names.rs
+++ b/benches/tables/fst/names.rs
@@ -6,8 +6,9 @@
 //
 // ucd-generate 0.2.10 is available on crates.io.
 
-lazy_static::lazy_static! {
-  pub static ref NAMES: ::fst::Map<&'static [u8]> =
-    ::fst::Map::from(::fst::raw::Fst::new(
-      &include_bytes!("names.fst")[..]).unwrap());
-}
+pub static NAMES: ::once_cell::sync::Lazy<::fst::Map<&'static [u8]>> =
+    ::once_cell::sync::Lazy::new(|| {
+        ::fst::Map::from(
+            ::fst::raw::Fst::new(&include_bytes!("names.fst")[..]).unwrap(),
+        )
+    });

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -916,19 +916,19 @@ impl Writer {
         File::create(fst_file_path)?.write_all(&fst.to_vec())?;
 
         let ty = if map { "Map" } else { "Set" };
-        writeln!(self.wtr, "lazy_static::lazy_static! {{")?;
         writeln!(
             self.wtr,
-            "  pub static ref {}: ::fst::{}<&'static [u8]> = ",
+            "pub static {}: ::once_cell::sync::Lazy<::fst::{}<&'static [u8]>> =",
             const_name, ty
         )?;
+        writeln!(self.wtr, "  ::once_cell::sync::Lazy::new(|| {{")?;
         writeln!(self.wtr, "    ::fst::{}::from(::fst::raw::Fst::new(", ty)?;
         writeln!(
             self.wtr,
-            "      &include_bytes!({:?})[..]).unwrap());",
+            "      &include_bytes!({:?})[..]).unwrap())",
             fst_file_name
         )?;
-        writeln!(self.wtr, "}}")?;
+        writeln!(self.wtr, "  }});")?;
         Ok(())
     }
 
@@ -1109,12 +1109,12 @@ impl Writer {
         file_name_fwd: &str,
         file_name_rev: &str,
     ) -> Result<()> {
-        writeln!(self.wtr, "lazy_static::lazy_static! {{")?;
         writeln!(
             self.wtr,
-            "  pub static ref {}: ::regex_automata::{} = {{",
+            "pub static {}: ::once_cell::sync::Lazy<::regex_automata::{}> =",
             const_name, full_regex_ty
         )?;
+        writeln!(self.wtr, "  ::once_cell::sync::Lazy::new(|| {{")?;
 
         writeln!(self.wtr, "    let fwd =")?;
         self.write_dfa_deserialize(short_dfa_ty, align_to, file_name_fwd)?;
@@ -1128,8 +1128,7 @@ impl Writer {
             self.wtr,
             "    ::regex_automata::Regex::from_dfas(fwd, rev)"
         )?;
-        writeln!(self.wtr, "  }};")?;
-        writeln!(self.wtr, "}}")?;
+        writeln!(self.wtr, "  }});")?;
 
         Ok(())
     }
@@ -1142,15 +1141,14 @@ impl Writer {
         align_to: &str,
         file_name: &str,
     ) -> Result<()> {
-        writeln!(self.wtr, "lazy_static::lazy_static! {{")?;
         writeln!(
             self.wtr,
-            "  pub static ref {}: ::regex_automata::{} = {{",
+            "pub static {}: ::once_cell::sync::Lazy<::regex_automata::{}> =",
             const_name, full_dfa_ty
         )?;
+        writeln!(self.wtr, "  ::once_cell::sync::Lazy::new(|| {{")?;
         self.write_dfa_deserialize(short_dfa_ty, align_to, file_name)?;
-        writeln!(self.wtr, "  }};")?;
-        writeln!(self.wtr, "}}")?;
+        writeln!(self.wtr, "  }});")?;
 
         Ok(())
     }

--- a/ucd-parse/Cargo.toml
+++ b/ucd-parse/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-lazy_static = "1"
+once_cell = "1"
 
 [dependencies.regex]
 version = "1"

--- a/ucd-parse/src/arabic_shaping.rs
+++ b/ucd-parse/src/arabic_shaping.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::common::{Codepoint, CodepointIter, UcdFile, UcdFileByCodepoint};
@@ -93,8 +93,8 @@ impl FromStr for ArabicShaping {
     type Err = Error;
 
     fn from_str(line: &str) -> Result<ArabicShaping, Error> {
-        lazy_static! {
-            static ref PARTS: Regex = Regex::new(
+        static PARTS: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(
                 r"(?x)
                 ^
                 \s*(?P<codepoint>[A-F0-9]+)\s*;
@@ -102,10 +102,10 @@ impl FromStr for ArabicShaping {
                 \s*(?P<joining_type>[^;]+)\s*;
                 \s*(?P<joining_group>[^;]+)
                 $
-                "
+                ",
             )
-            .unwrap();
-        };
+            .unwrap()
+        });
         let caps = match PARTS.captures(line.trim()) {
             Some(caps) => caps,
             None => return err!("invalid ArabicShaping line"),

--- a/ucd-parse/src/bidi_mirroring_glyph.rs
+++ b/ucd-parse/src/bidi_mirroring_glyph.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::common::{Codepoint, CodepointIter, UcdFile, UcdFileByCodepoint};
@@ -36,8 +36,8 @@ impl FromStr for BidiMirroring {
     type Err = Error;
 
     fn from_str(line: &str) -> Result<BidiMirroring, Error> {
-        lazy_static! {
-            static ref PARTS: Regex = Regex::new(
+        static PARTS: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(
                 r"(?x)
                 ^
                 \s*(?P<codepoint>[A-F0-9]+)\s*;
@@ -45,10 +45,10 @@ impl FromStr for BidiMirroring {
                 \s+
                 \#(?:.+)
                 $
-                "
+                ",
             )
-            .unwrap();
-        };
+            .unwrap()
+        });
         let caps = match PARTS.captures(line.trim()) {
             Some(caps) => caps,
             None => return err!("invalid BidiMirroring line"),

--- a/ucd-parse/src/case_folding.rs
+++ b/ucd-parse/src/case_folding.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::common::{Codepoint, CodepointIter, UcdFile, UcdFileByCodepoint};
@@ -42,17 +42,17 @@ impl FromStr for CaseFold {
     type Err = Error;
 
     fn from_str(line: &str) -> Result<CaseFold, Error> {
-        lazy_static! {
-            static ref PARTS: Regex = Regex::new(
+        static PARTS: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(
                 r"(?x)
                 ^
                 \s*(?P<codepoint>[^\s;]+)\s*;
                 \s*(?P<status>[^\s;]+)\s*;
                 \s*(?P<mapping>[^;]+)\s*;
-                "
+                ",
             )
-            .unwrap();
-        };
+            .unwrap()
+        });
 
         let caps = match PARTS.captures(line.trim()) {
             Some(caps) => caps,

--- a/ucd-parse/src/common.rs
+++ b/ucd-parse/src/common.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::error::{Error, ErrorKind};
@@ -85,10 +85,9 @@ pub fn ucd_directory_version<D: ?Sized + AsRef<Path>>(
     fn ucd_directory_version_inner(
         ucd_dir: &Path,
     ) -> Result<(u64, u64, u64), Error> {
-        lazy_static::lazy_static! {
-            static ref VERSION_RX: Regex =
-                Regex::new(r"-([0-9]+).([0-9]+).([0-9]+).txt").unwrap();
-        }
+        static VERSION_RX: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(r"-([0-9]+).([0-9]+).([0-9]+).txt").unwrap()
+        });
 
         let proplist = ucd_dir.join("PropList.txt");
         let contents = first_line(&proplist)?;
@@ -140,16 +139,16 @@ fn first_line(path: &Path) -> Result<String, Error> {
 pub fn parse_codepoint_association<'a>(
     line: &'a str,
 ) -> Result<(Codepoints, &'a str), Error> {
-    lazy_static! {
-        static ref PARTS: Regex = Regex::new(
+    static PARTS: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
             r"(?x)
             ^
             \s*(?P<codepoints>[^\s;]+)\s*;
             \s*(?P<property>[^;\x23]+)\s*
-            "
+            ",
         )
-        .unwrap();
-    };
+        .unwrap()
+    });
 
     let caps = match PARTS.captures(line.trim()) {
         Some(caps) => caps,
@@ -184,8 +183,8 @@ pub fn parse_codepoint_sequence(s: &str) -> Result<Vec<Codepoint>, Error> {
 /// with the comment associated with the test. The comment is a human readable
 /// description of the test that may prove useful for debugging.
 pub fn parse_break_test(line: &str) -> Result<(Vec<String>, String), Error> {
-    lazy_static! {
-        static ref PARTS: Regex = Regex::new(
+    static PARTS: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
             r"(?x)
             ^
             (?:÷|×)
@@ -193,16 +192,18 @@ pub fn parse_break_test(line: &str) -> Result<(Vec<String>, String), Error> {
             \s+
             \#(?P<comment>.+)
             $
-            "
+            ",
         )
-        .unwrap();
-        static ref GROUP: Regex = Regex::new(
+        .unwrap()
+    });
+    static GROUP: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
             r"(?x)
             (?P<codepoint>[0-9A-Fa-f]{4,5})\s(?P<kind>÷|×)
-            "
+            ",
         )
-        .unwrap();
-    }
+        .unwrap()
+    });
 
     let caps = match PARTS.captures(line.trim()) {
         Some(caps) => caps,
@@ -458,11 +459,10 @@ impl FromStr for CodepointRange {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<CodepointRange, Error> {
-        lazy_static! {
-            static ref PARTS: Regex =
-                Regex::new(r"^(?P<start>[A-Z0-9]+)\.\.(?P<end>[A-Z0-9]+)$")
-                    .unwrap();
-        }
+        static PARTS: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(r"^(?P<start>[A-Z0-9]+)\.\.(?P<end>[A-Z0-9]+)$")
+                .unwrap()
+        });
         let caps = match PARTS.captures(s) {
             Some(caps) => caps,
             None => return err!("invalid codepoint range: '{}'", s),

--- a/ucd-parse/src/extracted/derived_numeric_values.rs
+++ b/ucd-parse/src/extracted/derived_numeric_values.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::common::{CodepointIter, Codepoints, UcdFile, UcdFileByCodepoint};
@@ -38,18 +38,18 @@ impl FromStr for DerivedNumericValues {
     type Err = Error;
 
     fn from_str(line: &str) -> Result<DerivedNumericValues, Error> {
-        lazy_static! {
-            static ref PARTS: Regex = Regex::new(
+        static PARTS: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(
                 r"(?x)
                 ^
                 \s*(?P<codepoints>[^\s;]+)\s*;
                 \s*(?P<numeric_value_decimal>[^\s;]+)\s*;
                 \s*;
                 \s*(?P<numeric_value_fraction>[^\s;]+)\s*
-                "
+                ",
             )
-            .unwrap();
-        };
+            .unwrap()
+        });
 
         let caps = match PARTS.captures(line.trim()) {
             Some(caps) => caps,

--- a/ucd-parse/src/jamo_short_name.rs
+++ b/ucd-parse/src/jamo_short_name.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::common::{Codepoint, CodepointIter, UcdFile, UcdFileByCodepoint};
@@ -35,17 +35,17 @@ impl FromStr for JamoShortName {
     type Err = Error;
 
     fn from_str(line: &str) -> Result<JamoShortName, Error> {
-        lazy_static! {
-            static ref PARTS: Regex = Regex::new(
+        static PARTS: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(
                 r"(?x)
                 ^
                 (?P<codepoint>[A-Z0-9]+);
                 \s*
                 (?P<name>[A-Z]*)
-                "
+                ",
             )
-            .unwrap();
-        };
+            .unwrap()
+        });
 
         let caps = match PARTS.captures(line.trim()) {
             Some(caps) => caps,

--- a/ucd-parse/src/name_aliases.rs
+++ b/ucd-parse/src/name_aliases.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::common::{Codepoint, CodepointIter, UcdFile, UcdFileByCodepoint};
@@ -37,8 +37,8 @@ impl FromStr for NameAlias {
     type Err = Error;
 
     fn from_str(line: &str) -> Result<NameAlias, Error> {
-        lazy_static! {
-            static ref PARTS: Regex = Regex::new(
+        static PARTS: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(
                 r"(?x)
                 ^
                 (?P<codepoint>[A-Z0-9]+);
@@ -46,10 +46,10 @@ impl FromStr for NameAlias {
                 (?P<alias>[^;]+);
                 \s*
                 (?P<label>\S+)
-                "
+                ",
             )
-            .unwrap();
-        };
+            .unwrap()
+        });
 
         let caps = match PARTS.captures(line.trim()) {
             Some(caps) => caps,

--- a/ucd-parse/src/property_aliases.rs
+++ b/ucd-parse/src/property_aliases.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::common::UcdFile;
@@ -28,19 +28,20 @@ impl FromStr for PropertyAlias {
     type Err = Error;
 
     fn from_str(line: &str) -> Result<PropertyAlias, Error> {
-        lazy_static! {
-            static ref PARTS: Regex = Regex::new(
+        static PARTS: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(
                 r"(?x)
                 ^
                 \s*(?P<abbrev>[^\s;]+)\s*;
                 \s*(?P<long>[^\s;]+)\s*
                 (?:;(?P<aliases>.*))?
-                "
+                ",
             )
-            .unwrap();
-            static ref ALIASES: Regex =
-                Regex::new(r"\s*(?P<alias>[^\s;]+)\s*;?\s*").unwrap();
-        };
+            .unwrap()
+        });
+        static ALIASES: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(r"\s*(?P<alias>[^\s;]+)\s*;?\s*").unwrap()
+        });
 
         let caps = match PARTS.captures(line.trim()) {
             Some(caps) => caps,

--- a/ucd-parse/src/property_value_aliases.rs
+++ b/ucd-parse/src/property_value_aliases.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::common::UcdFile;
@@ -34,30 +34,33 @@ impl FromStr for PropertyValueAlias {
     type Err = Error;
 
     fn from_str(line: &str) -> Result<PropertyValueAlias, Error> {
-        lazy_static! {
-            static ref PARTS: Regex = Regex::new(
+        static PARTS: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(
                 r"(?x)
                 ^
                 \s*(?P<prop>[^\s;]+)\s*;
                 \s*(?P<abbrev>[^\s;]+)\s*;
                 \s*(?P<long>[^\s;]+)\s*
                 (?:;(?P<aliases>.*))?
-                "
+                ",
             )
-            .unwrap();
-            static ref PARTS_CCC: Regex = Regex::new(
+            .unwrap()
+        });
+        static PARTS_CCC: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(
                 r"(?x)
                 ^
                 ccc;
                 \s*(?P<num_class>[0-9]+)\s*;
                 \s*(?P<abbrev>[^\s;]+)\s*;
                 \s*(?P<long>[^\s;]+)
-                "
+                ",
             )
-            .unwrap();
-            static ref ALIASES: Regex =
-                Regex::new(r"\s*(?P<alias>[^\s;]+)\s*;?\s*").unwrap();
-        };
+            .unwrap()
+        });
+        static ALIASES: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(r"\s*(?P<alias>[^\s;]+)\s*;?\s*").unwrap()
+        });
 
         if line.starts_with("ccc;") {
             let caps = match PARTS_CCC.captures(line.trim()) {

--- a/ucd-parse/src/special_casing.rs
+++ b/ucd-parse/src/special_casing.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::common::{
@@ -46,8 +46,8 @@ impl FromStr for SpecialCaseMapping {
     type Err = Error;
 
     fn from_str(line: &str) -> Result<SpecialCaseMapping, Error> {
-        lazy_static! {
-            static ref PARTS: Regex = Regex::new(
+        static PARTS: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(
                 r"(?x)
                 ^
                 \s*(?P<codepoint>[^\s;]+)\s*;
@@ -55,10 +55,10 @@ impl FromStr for SpecialCaseMapping {
                 \s*(?P<title>[^;]+)\s*;
                 \s*(?P<upper>[^;]+)\s*;
                 \s*(?P<conditions>[^;\x23]+)?
-                "
+                ",
             )
-            .unwrap();
-        };
+            .unwrap()
+        });
 
         let caps = match PARTS.captures(line.trim()) {
             Some(caps) => caps,

--- a/ucd-trie/Cargo.toml
+++ b/ucd-trie/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dev-dependencies]
-lazy_static = "1"
+once_cell = "1"
 
 [features]
 default = ["std"]

--- a/ucd-trie/benches/bench.rs
+++ b/ucd-trie/benches/bench.rs
@@ -1,21 +1,18 @@
 #![feature(test)]
 
-#[macro_use]
-extern crate lazy_static;
 extern crate test;
 
+use once_cell::sync::Lazy;
 use ucd_trie::TrieSetOwned;
 
 #[bench]
 fn bench_trie_set(b: &mut test::Bencher) {
     const CHARS: &'static [char] = &['a', 'β', '☃', '😼'];
     // const CHARS: &'static [char] = &['a'];
-    lazy_static! {
-        static ref SET: TrieSetOwned =
-            TrieSetOwned::from_scalars(CHARS).unwrap();
-    }
+    static SET: Lazy<TrieSetOwned> =
+        Lazy::new(|| TrieSetOwned::from_scalars(CHARS).unwrap());
 
-    let set = &*SET;
+    let set = Lazy::force(&SET);
     let mut i = 0;
     b.iter(|| {
         let c = CHARS[i];


### PR DESCRIPTION
Part of https://github.com/BurntSushi/bstr/issues/124. I'm in a similar situation as lopopolo where `bstr` is the only crate still pulling in lazy_static.