### PR TITLE
cli: support `case-mapping --include=UPPER|LOWER|TITLE` flag

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -571,6 +571,21 @@ pub fn app() -> App<'static, 'static> {
              (emit maps of codepoint to codepoint, \
              ignoring rules from SpecialCasing.txt)",
         ))
+        .arg(
+            Arg::with_name("include")
+                .long("include")
+                .possible_value("UPPER")
+                .possible_value("LOWER")
+                .possible_value("TITLE")
+                .value_name("UPPER|LOWER|TITLE")
+                .takes_value(true)
+                .multiple(true)
+                .help(
+                    "Only include some case mapping. \
+                     Can be specified multiple times. \
+                     When absent, all case mapping are included.",
+                ),
+        )
         .arg(flag_flat_table.clone().conflicts_with("simple"));
 
     let cmd_grapheme_cluster_break =

--- a/src/case_mapping.rs
+++ b/src/case_mapping.rs
@@ -23,6 +23,13 @@ pub fn command(args: ArgMatches<'_>) -> Result<()> {
             title_map.insert(item.codepoint.value(), vec![title.value()]);
         }
     }
+
+    let includes = if let Some(what) = args.values_of("include") {
+        what.clone().collect::<Vec<_>>()
+    } else {
+        vec!["LOWER", "UPPER", "TITLE"]
+    };
+
     if args.is_present("simple") {
         let upper_map =
             upper_map.into_iter().map(|(k, v)| (k, v[0])).collect();
@@ -30,9 +37,15 @@ pub fn command(args: ArgMatches<'_>) -> Result<()> {
             lower_map.into_iter().map(|(k, v)| (k, v[0])).collect();
         let title_map =
             title_map.into_iter().map(|(k, v)| (k, v[0])).collect();
-        wtr.codepoint_to_codepoint("LOWER", &upper_map)?;
-        wtr.codepoint_to_codepoint("UPPER", &lower_map)?;
-        wtr.codepoint_to_codepoint("TITLE", &title_map)?;
+
+        for name in includes {
+            match name {
+                "LOWER" => wtr.codepoint_to_codepoint("LOWER", &lower_map)?,
+                "UPPER" => wtr.codepoint_to_codepoint("UPPER", &upper_map)?,
+                "TITlE" => wtr.codepoint_to_codepoint("TITlE", &title_map)?,
+                _ => (),
+            }
+        }
     } else {
         for special in SpecialCaseMapping::from_dir(&dir)? {
             let special = special?;
@@ -61,9 +74,20 @@ pub fn command(args: ArgMatches<'_>) -> Result<()> {
             }
         }
         let flat = args.is_present("flat-table");
-        wtr.codepoint_to_codepoints("LOWER", &lower_map, flat)?;
-        wtr.codepoint_to_codepoints("UPPER", &upper_map, flat)?;
-        wtr.codepoint_to_codepoints("TITLE", &title_map, flat)?;
+        for name in includes {
+            match name {
+                "LOWER" => {
+                    wtr.codepoint_to_codepoints("LOWER", &lower_map, flat)?
+                }
+                "UPPER" => {
+                    wtr.codepoint_to_codepoints("UPPER", &upper_map, flat)?
+                }
+                "TITLE" => {
+                    wtr.codepoint_to_codepoints("TITLE", &title_map, flat)?
+                }
+                _ => (),
+            }
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
Thanks for creating this crate. I personally find it would be pretty helpful if the `case-mapping` command could generate only a subset of `UPPER`, `LOWER` and `TITLE`, so I just [create a PR](https://github.com/BurntSushi/ucd-generate#contributing) to discuss the idea.

For more context, the [exact scenario](https://github.com/artichoke/roe/pull/139#discussion_r1244608792) is that I only need `TITLE`, so both `UPPER` and `LOWER` would be unused. This [`dead_code`](https://doc.rust-lang.org/rust-by-example/attribute/unused.html) violation makes compiler/clippy unhappy, and it couldn't be autocorrected with `cargo clippy --fix`.

## Example usage


<details><summary><code>cargo run -- case-mapping ./x --include TITLE</code> (Only generate <code>TITLE</code>)</summary>

```
$ cargo run -- case-mapping ./x --include TITLE
// DO NOT EDIT THIS FILE. IT WAS AUTOMATICALLY GENERATED BY:
//
//   ucd-generate case-mapping ./x --include TITLE
//
// Unicode version: 15.0.0.
//
// ucd-generate 0.2.15 is available on crates.io.

pub const TITLE: &'static [(u32, &'static [u32])] = &[
  (97, &[65]), (98, &[66]), (99, &[67]), (100, &[68]), (101, &[69]), (102, &[70
  ...
  (125250, &[125216]), (125251, &[125217]),
];
```

</details>


<details><summary><code>cargo run -- case-mapping ./x --include UPPER --include LOWER</code> (Multiple <code>--include</code>s)</summary>

```
$ cargo run -- case-mapping ./x --include UPPER --include LOWER

// DO NOT EDIT THIS FILE. IT WAS AUTOMATICALLY GENERATED BY:
//
//   ucd-generate case-mapping ./x --include UPPER --include LOWER
//
// Unicode version: 15.0.0.
//
// ucd-generate 0.2.15 is available on crates.io.

pub const UPPER: &'static [(u32, &'static [u32])] = &[
  (97, &[65]), (98, &[66]), (99, &[67]), (100, &[68]), (101, &[69]), (102, &[70
  ...
  125214]), (125249, &[125215]), (125250, &[125216]), (125251, &[125217]),
];

pub const LOWER: &'static [(u32, &'static [u32])] = &[
  (65, &[97]), (66, &[98]), (67, &[99]), (68, &[100]), (69, &[101]), (70, &[102
  ...
  (125216, &[125250]), (125217, &[125251]),
];
```

</details>

<details><summary><code>cargo run -- case-mapping ./x --include TYPO</code></summary>

```
$ cargo run -- case-mapping ./x --include TYPO
error: 'TYPO' isn't a valid value for '--include <UPPER|LOWER|TITLE>...'
	[possible values: LOWER, TITLE, UPPER]


USAGE:
    ucd-generate case-mapping <ucd-dir> --include <UPPER|LOWER|TITLE>... --name <name>

For more information try --help
```

</details>

<details><summary><code>cargo run -- case-mapping ./x</code> (Current behavior unchanged)</summary>

```
$ cargo run -- case-mapping ./x

// DO NOT EDIT THIS FILE. IT WAS AUTOMATICALLY GENERATED BY:
//
//   ucd-generate case-mapping ./x
//
// Unicode version: 15.0.0.
//
// ucd-generate 0.2.15 is available on crates.io.

pub const LOWER: &'static [(u32, &'static [u32])] = &[
  (65, &[97]), (66, &[98]), (67, &[99]), (68, &[100]), (69, &[101]), (70, &[102
  ...
  (125216, &[125250]), (125217, &[125251]),
];

pub const UPPER: &'static [(u32, &'static [u32])] = &[
  (97, &[65]), (98, &[66]), (99, &[67]), (100, &[68]), (101, &[69]), (102, &[70
  ...
  125214]), (125249, &[125215]), (125250, &[125216]), (125251, &[125217]),
];

pub const TITLE: &'static [(u32, &'static [u32])] = &[
  (97, &[65]), (98, &[66]), (99, &[67]), (100, &[68]), (101, &[69]), (102, &[70
  ...
  (125250, &[125216]), (125251, &[125217]),
];
```

</details>


<details><summary><code>cargo run -- case-mapping ./x --help</code> (The new help message)</summary>

```
$ cargo run -- case-mapping ./x --help        

    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/ucd-generate case-mapping ./x --help`
case-mapping emits case mapping tables, which map from a codepoint to a
list of codepoints (currently up to three), and are used to convert
text between lower, upper, and title cases.

This command currently has no support for emitting the conditional case
mapping data, and can only produce the unconditional mapping tables.

USAGE:
    ucd-generate case-mapping [FLAGS] [OPTIONS] <ucd-dir>

ARGS:
    <ucd-dir>    Directory containing the Unicode character database files.

OPTIONS:
        --chars
            Write codepoints as character literals. If a codepoint cannot be written as a character
            literal, then it is silently dropped.
        --flat-table
            When emitting a map of a single codepoint to multiple codepoints, emit entries as `(u32,
            [u32; 3])` instead of as `(u32, &[u32])` (replacing `u32` with `char` if `--chars` is
            passed). Conceptually unoccupied indices of the array will contain `!0u32` (for u32) or
            `\u{0}` (for `char`).
    -h, --help                              Prints help information
        --include <UPPER|LOWER|TITLE>...
            Only include some case mapping. Can be specified multiple times. When absent, all case
            mapping are included. [possible values: UPPER, LOWER, TITLE]
        --name <name>
            Set the name of the table in the emitted code. [default: CASE_MAPPING]

        --simple
            Only emit the simple case mapping tables (emit maps of codepoint to codepoint, ignoring
            rules from SpecialCasing.txt)
    -V, --version                           Prints version information
```

</details>